### PR TITLE
messages: support appdirs user_log_dir for darwin

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, ubuntu-18.04, ubuntu-20.04]
         python-version: [3.8, 3.9]
 
     runs-on: ${{ matrix.os }}

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -91,7 +91,7 @@ def _get_log_filepath(appname: str) -> pathlib.Path:
     Existing files are not renamed (no need, as each name is unique) nor gzipped (they may
     be currently in use by another process).
     """
-    basedir = pathlib.Path(appdirs.user_log_dir()) / appname
+    basedir = pathlib.Path(appdirs.user_log_dir(appname))
     filename = f"{appname}-{datetime.now():%Y%m%d-%H%M%S.%f}.log"
 
     # ensure the basedir is there

--- a/tests/unit/test_messages_helpers.py
+++ b/tests/unit/test_messages_helpers.py
@@ -46,7 +46,7 @@ def test_log_dir(tmp_path, monkeypatch):
     """Provide a test log filepath, also fixing appdirs to use a temp dir."""
     dirpath = tmp_path / "testlogdir"
     dirpath.mkdir()
-    monkeypatch.setattr(appdirs, "user_log_dir", lambda: dirpath)
+    monkeypatch.setattr(appdirs, "user_log_dir", lambda appname: dirpath / appname)
     return dirpath
 
 
@@ -145,7 +145,7 @@ def test_getlogpath_ignore_other_files(test_log_dir, monkeypatch):
 def test_getlogpath_deep_dirs(tmp_path, monkeypatch):
     """The log directory is inside a path that does not exist yet."""
     dirpath = tmp_path / "foo" / "bar" / "testlogdir"
-    monkeypatch.setattr(appdirs, "user_log_dir", lambda: dirpath)
+    monkeypatch.setattr(appdirs, "user_log_dir", lambda appname: dirpath / appname)
     fpath = _get_log_filepath("testapp")
 
     # check the file is inside the proper dir and that it exists


### PR DESCRIPTION
appdirs.user_log_dir takes appname as the first parameter and while
the code path works when it is None for windows and linux, it runs
`os.path.expandpath("~/...", appname)` and darwin which fails as
appname is None.

https://github.com/ActiveState/appdirs/blob/48357882e5c095003e10f8351b405bf54e41424f/appdirs.py#L395

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----