### PR TITLE
Avoid showing the spinner on complete line messages (that end with newline).

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -159,7 +159,7 @@ class _Spinner(threading.Thread):
             except queue.Empty:
                 # waited too much, start to show a spinner (if have a previous message) until
                 # we have further info
-                if prv_msg is None:
+                if prv_msg is None or prv_msg.end_line:
                     continue
                 spinchars = itertools.cycle("-\\|/")
                 with self.lock:

--- a/tests/unit/test_messages_helpers.py
+++ b/tests/unit/test_messages_helpers.py
@@ -333,6 +333,17 @@ def test_spinner_in_the_vacuum(spinner, monkeypatch):
     assert spinner.printer.spinned == []
 
 
+def test_spinner_silent_on_complete_messages(spinner, monkeypatch):
+    """Nothing happens before the threshold time."""
+    monkeypatch.setattr(messages, "_SPINNER_THRESHOLD", 0.001)
+    spinner.supervise(_MessageInfo(sys.stdout, "test msg 1", end_line=True))
+
+    # enough time for activation
+    time.sleep(0.05)
+
+    assert spinner.printer.spinned == []
+
+
 # -- tests for the _Handler class
 
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This can easily be experimented in real life before/after the change doing `./examples.py 18`.