### PR TITLE
docs: move API gen to conf.py for RTD to pick up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ coverage: ## Run pytest with coverage report.
 docs: ## Generate documentation.
 	rm -f docs/craft_cli.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ craft_cli --no-toc --ext-githubpages
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,10 +30,10 @@
 import os
 import sys
 
-import craft_cli
-
 
 sys.path.insert(0, os.path.abspath(".."))
+
+import craft_cli  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------
@@ -91,3 +91,18 @@ typehints_document_rtype = True
 
 # Enable support for google-style instance attributes.
 napoleon_use_ivar = True
+
+
+def run_apidoc(_):
+    from sphinx.ext.apidoc import main
+    import os
+    import sys
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    module = os.path.join(cur_dir, "..", "craft_cli")
+    main(["-e", "-o", cur_dir, module, "--no-toc", "--force"])
+
+
+def setup(app):
+    app.connect("builder-inited", run_apidoc)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,9 @@
-Welcome to Craft Store's documentation!
+Welcome to Craft CLI's documentation!
 ===========================================
 
 .. toctree::
    :caption: Reference:
+   :maxdepth: 2
 
    craft_cli
 


### PR DESCRIPTION
Read The Docs can build the API documentation (reference) by moving
sphinx-apidoc to conf.py which is its entry point for building.

Some typos were also corrected.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----