### PR TITLE
Declare public API names

### DIFF
--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -16,6 +16,10 @@
 
 """Error classes."""
 
+__all__ = [
+    "CraftError",
+]
+
 from typing import Optional
 
 

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -16,6 +16,12 @@
 
 """Support for all messages, ok or after errors, to screen and log file."""
 
+__all__ = [
+    "EmitterMode",
+    "TESTMODE",
+    "emit",
+]
+
 import enum
 import itertools
 import logging


### PR DESCRIPTION
`mypy --strict` enforces these by default.

I'm not sure whether `Emitter` should be public.  It doesn't have an underscore, but it also isn't used by charmcraft - I guess it might be needed to implement test fixtures?  I decided to err on the side of strictness and you can always open it up if you want.

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?  (Canonical employee, so not required.)

-----
