### PR TITLE
Implement comparison for CraftError

### DIFF
--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -62,13 +62,12 @@ class CraftError(Exception):
         if isinstance(other, CraftError):
             return all(
                 [
-                    self.args == getattr(other, "args"),
-                    self.details == getattr(other, "details"),
-                    self.resolution == getattr(other, "resolution"),
-                    self.docs_url == getattr(other, "docs_url"),
-                    self.reportable == getattr(other, "reportable"),
-                    self.retcode == getattr(other, "retcode"),
+                    self.args == other.args,
+                    self.details == other.details,
+                    self.resolution == other.resolution,
+                    self.docs_url == other.docs_url,
+                    self.reportable == other.reportable,
+                    self.retcode == other.retcode,
                 ]
             )
-        else:
-            return NotImplemented
+        return NotImplemented

--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -57,3 +57,18 @@ class CraftError(Exception):
         self.docs_url = docs_url
         self.reportable = reportable
         self.retcode = retcode
+
+    def __eq__(self, other):
+        if isinstance(other, CraftError):
+            return all(
+                [
+                    self.args == getattr(other, "args"),
+                    self.details == getattr(other, "details"),
+                    self.resolution == getattr(other, "resolution"),
+                    self.docs_url == getattr(other, "docs_url"),
+                    self.reportable == getattr(other, "reportable"),
+                    self.retcode == getattr(other, "retcode"),
+                ]
+            )
+        else:
+            return NotImplemented

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from craft_cli.errors import CraftError
 
 
@@ -20,3 +22,41 @@ def test_crafterror_does_not_compare_to_other_exception():
     b = ValueError("foo")
 
     assert a != b
+
+
+@pytest.mark.parametrize(
+    "argument_name",
+    [
+        "details",
+        "resolution",
+        "docs_url",
+        "reportable",
+        "retcode",
+    ],
+)
+def test_compare_crafterror_with_different_attribute_values(argument_name):
+    a = CraftError("message")
+    b = CraftError("message")
+    setattr(a, argument_name, "foo")
+    setattr(b, argument_name, "bar")
+
+    assert a != b
+
+
+@pytest.mark.parametrize(
+    "argument_name",
+    [
+        "details",
+        "resolution",
+        "docs_url",
+        "reportable",
+        "retcode",
+    ],
+)
+def test_compare_crafterror_with_identical_attribute_values(argument_name):
+    a = CraftError("message")
+    b = CraftError("message")
+    setattr(a, argument_name, "foo")
+    setattr(b, argument_name, "foo")
+
+    assert a == b

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,22 @@
+from craft_cli.errors import CraftError
+
+
+def test_crafterror_is_comparable():
+    a = CraftError("foo")
+    b = CraftError("foo")
+
+    assert a == b
+
+
+def test_crafterror_is_different():
+    a = CraftError("foo")
+    b = CraftError("bar")
+
+    assert a != b
+
+
+def test_crafterror_does_not_compare_to_other_exception():
+    a = CraftError("foo")
+    b = ValueError("foo")
+
+    assert a != b


### PR DESCRIPTION
This is especially helpful for testing purposes so that the actual instance
of CraftError can be compared with the expected one.

This fixes #40

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
(not necessary -> Canonical employee)

-----
