### PR TITLE
Fix tox environment setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@ envlist = py38
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    -r{toxinidir}/requirements-dev.txt
-    -r{toxinidir}/requirements.txt
+    .[dev]
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}


### PR DESCRIPTION
The requirements files were removed a while ago, but `tox.ini` still
referenced them.