### PR TITLE
Only show spinners if the stream is a terminal

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -322,11 +322,15 @@ class _Printer:
             return
 
         if msg.bar_progress is None:
-            # regular message, send it to the spinner and write it
-            self.spinner.supervise(msg)
+            # regular message, send it to the spinner (if the stream is a
+            # terminal) and write it
+            if getattr(msg.stream, "isatty", lambda: False)():
+                self.spinner.supervise(msg)
+            else:
+                self.spinner.supervise(None)
             self._write_line(msg)
         else:
-            # progress bar, send None to the spinner (as it's not a "spinneable" message)
+            # progress bar, send None to the spinner (as it's not a "spinnable" message)
             # and write it
             self.spinner.supervise(None)
             self._write_bar(msg)

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -64,6 +64,11 @@ class _MessageInfo:  # pylint: disable=too-many-instance-attributes
     end_line: bool = False
     created_at: datetime = field(default_factory=datetime.now)
 
+    @property
+    def stream_is_terminal(self) -> bool:
+        """Return whether the message's stream is a terminal."""
+        return getattr(self.stream, "isatty", lambda: False)()
+
 
 # the different modes the Emitter can be set
 EmitterMode = enum.Enum("EmitterMode", "QUIET NORMAL VERBOSE TRACE")
@@ -324,7 +329,7 @@ class _Printer:
         if msg.bar_progress is None:
             # regular message, send it to the spinner (if the stream is a
             # terminal) and write it
-            if getattr(msg.stream, "isatty", lambda: False)():
+            if msg.stream_is_terminal:
                 self.spinner.supervise(msg)
             else:
                 self.spinner.supervise(None)

--- a/tests/unit/test_messages_printer.py
+++ b/tests/unit/test_messages_printer.py
@@ -524,9 +524,11 @@ def test_show_defaults_no_stream(recording_printer):
     assert not recording_printer.spinner.supervised
 
 
+@pytest.mark.parametrize("isatty", [True, False])
 @pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
-def test_show_defaults(stream, recording_printer):
+def test_show_defaults(stream, isatty, recording_printer):
     """Write a message with all defaults (for the different valid streams)."""
+    stream.isatty = lambda: isatty
     before = datetime.now()
     recording_printer.show(stream, "test text")
 
@@ -549,8 +551,12 @@ def test_show_defaults(stream, recording_printer):
     (logged,) = recording_printer.logged
     assert msg is logged
 
-    # the spinner now has the shown message to supervise
-    assert recording_printer.spinner.supervised == [msg]
+    if isatty:
+        # the spinner now has the shown message to supervise
+        assert recording_printer.spinner.supervised == [msg]
+    else:
+        # no spinner when the stream is not a terminal
+        assert recording_printer.spinner.supervised == [None]
 
 
 def test_show_use_timestamp(recording_printer):


### PR DESCRIPTION
If the output stream isn't a terminal (for example, if *craft is running
in a Launchpad build job), then showing spinners isn't very useful and
results in build logs parts of which are quite hard to read.  Limit this
behaviour to terminals.