### PR TITLE
api: declare public api names

### DIFF
--- a/craft_cli/__init__.py
+++ b/craft_cli/__init__.py
@@ -23,3 +23,15 @@ __version__ = "0.0.1.dev1"
 from .messages import EmitterMode, emit  # noqa: F401 ; isort:skip
 from .dispatcher import BaseCommand, CommandGroup, Dispatcher, GlobalArgument  # noqa: F401
 from .errors import ArgumentParsingError, CraftError, ProvideHelpException  # noqa: F401
+
+__all__ = [
+    "ArgumentParsingError",
+    "BaseCommand",
+    "CommandGroup",
+    "CraftError",
+    "Dispatcher",
+    "EmitterMode",
+    "GlobalArgument",
+    "ProvideHelpException",
+    "emit",
+]


### PR DESCRIPTION
Explicitly export public API names. This is enforced by pyright in
packages with the PEP-561 `py.typed` marker.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
