### PR TITLE
Add a 'pause' method to the Emitter (CRAFT-907).

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -35,6 +35,7 @@ import sys
 import threading
 import time
 import traceback
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
@@ -775,6 +776,21 @@ class Emitter:
         else:
             stream = sys.stderr
         return _StreamContextManager(self._printer, text, stream)  # type: ignore
+
+    @_init_guard
+    @contextmanager
+    def pause(self):
+        """Context manager that pauses and resumes the control of the terminal.
+
+        Note that no messages will be collected while paused, not even for logging.
+        """
+        self.trace("Emitter: Pausing control of the terminal")
+        self._printer.stop()  # type: ignore
+        try:
+            yield
+        finally:
+            self._printer = _Printer(self._log_filepath)  # type: ignore
+            self.trace("Emitter: Resuming control of the terminal")
 
     def _stop(self) -> None:
         """Do all the stopping."""

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -153,3 +153,16 @@ This way ``craft-cli`` will run the specified command if none was given, e.g.::
 And even run the specified default command if options are given for that command::
 
     $ my-super-app --important-option
+
+
+Allow temporarily other application to control the terminal
+===========================================================
+
+To be able to run another application (in other process) without interfering in the use of the terminal between the main application and the sub-executed one, you need to pause the emitter::
+
+    with emit.pause():
+        subprocess.run(["someapp"])
+
+When the emitter is paused the terminal is freed, and the emitter does not have control on what happens in the terminal there until it's resumed, not even for logging purposes.
+
+The normal behaviour is resumed when the context manager exits (even if an exception was raised inside).


### PR DESCRIPTION
While paused, the Emitter frees completely the terminal and does not do anything with it. Not even getting logs from it.

Examples 21 and 22 added to easily test this new feature.
