### PR TITLE
Improvements/fixes for the pause situation.

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -605,7 +605,7 @@ class _Handler(logging.Handler):
 def _active_guard(ignore_when_stopped=False):
     """Decorate Emitter methods to be called when active.
 
-    It will check that the emitter is initted and that is not stopped (except when
+    It will check that the emitter is initiated and that is not stopped (except when
     ignore_when_stopped=True, in that case the call will be ignored, to support
     double-ending).
     """

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -611,7 +611,7 @@ def _active_guard(ignore_when_stopped=False):
     """
 
     def decorator(wrapped_func):
-        def func(self, *args, **kwargs):
+        def func(self, *args, **kwargs):  # pylint: disable=inconsistent-return-statements
             if not self._initiated:  # pylint: disable=protected-access
                 raise RuntimeError("Emitter needs to be initiated first")
             if self._stopped:  # pylint: disable=protected-access

--- a/examples.py
+++ b/examples.py
@@ -246,7 +246,7 @@ def _run_subprocess_with_emitter(mode):
     time.sleep(3)
     with emit.pause():
         subprocess.run([sys.executable, temp_name, mode.name], env={"PYTHONPATH": os.getcwd()})
-        # here we should collect the logs from the sub application
+        # note we cannot use `emit` while paused!
     os.unlink(temp_name)
     emit.message("All done!")
 

--- a/tests/unit/test_messages_printer.py
+++ b/tests/unit/test_messages_printer.py
@@ -484,7 +484,7 @@ def test_logfile_opened(log_filepath):
     """The logfile is properly opened."""
     printer = _Printer(log_filepath)
     assert not printer.log.closed
-    assert printer.log.mode == "wt"
+    assert printer.log.mode == "at"
     assert printer.log.encoding == "utf8"
 
 


### PR DESCRIPTION
- the _Printer now opens the log in "append" mode; this is particularly so after resuming the previous log is not truncated, but also is an improvement in general, as we allow users of the library to have better control if they provide the log filepath (if they want a fresh start, they can truncate it, before we were not leaving a choice)

- ensure the _Emitter is not used when paused... but I fixed this in a more generic way, ensuring that the _Emitter is not used when stopped! Except for the `ended_ok` and `error` methods, where we provide the possibility of double-endings (ignoring the call), to support race conditions when closing the lib. 
