### PR TITLE
Added init_emitter and emitter fixtures (CRAFT-994).

### DIFF
--- a/craft_cli/pytest_plugin.py
+++ b/craft_cli/pytest_plugin.py
@@ -28,7 +28,7 @@ from craft_cli import messages
 
 
 @pytest.fixture(autouse=True)
-def init_emitter():
+def init_emitter(monkeypatch):
     """Ensure emit is always clean, and initted (in test mode).
 
     Note that the `init` is done in the current instance that all modules already
@@ -42,7 +42,7 @@ def init_emitter():
     os.close(temp_fd)
     temp_logfile = pathlib.Path(temp_logfile)
 
-    messages.TESTMODE = True
+    monkeypatch.setattr(messages, "TESTMODE", True)
     messages.emit.init(
         messages.EmitterMode.QUIET, "test-emitter", "Hello world", log_filepath=temp_logfile
     )

--- a/craft_cli/pytest_plugin.py
+++ b/craft_cli/pytest_plugin.py
@@ -29,15 +29,17 @@ from craft_cli import messages
 
 @pytest.fixture(autouse=True)
 def init_emitter(monkeypatch):
-    """Ensure emit is always clean, and initted (in test mode).
+    """Ensure ``emit`` is always clean, and initiated (in test mode).
 
-    Note that the `init` is done in the current instance that all modules already
+    Note that the ``init`` is done in the current instance that all modules already
     acquired.
+
+    This is an "autouse" fixture, so it just works, no need to declare it in your tests.
     """
-    # init with a custom log filepath so user directories are not involved here; note that
+    # initiate with a custom log filepath so user directories are not involved here; note that
     # we're not using pytest's standard tmp_path as Emitter would write logs there, and in
     # effect we would be polluting that temporary directory (potentially messing with
-    # tests, that may need that empty), so we use another one.
+    # tests, that may need that empty), so we use another one
     temp_fd, temp_logfile = tempfile.mkstemp(prefix="emitter-logs")
     os.close(temp_fd)
     temp_logfile = pathlib.Path(temp_logfile)
@@ -62,8 +64,12 @@ class _RegexComparingText(str):
         return str.__hash__(self)
 
 
-class _RecordingEmitter:
-    """Record what is shown using the emitter and provide a nice API for tests."""
+class RecordingEmitter:
+    """Record what is shown using the emitter and provide a nice API for tests.
+
+    This class is NOT meant to be used directly, please use the ``emitter`` fixture instead
+    which provides an instance of this class with context properly set up.
+    """
 
     def __init__(self):
         self.interactions = []
@@ -171,8 +177,8 @@ class _RecordingProgresser:
 
 @pytest.fixture
 def emitter(monkeypatch):
-    """Provide a helper to test everything that was shown using craft-cli Emitter."""
-    recording_emitter = _RecordingEmitter()
+    """Provide a helper to test everything that was shown using the Emitter."""
+    recording_emitter = RecordingEmitter()
     for method_name in ("message", "progress", "trace"):
         monkeypatch.setattr(
             messages.emit,

--- a/craft_cli/pytest_plugin.py
+++ b/craft_cli/pytest_plugin.py
@@ -1,0 +1,172 @@
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Different fixtures for easier testability of Craft CLI services."""
+
+import contextlib
+import os
+import pathlib
+import re
+import tempfile
+from unittest.mock import call
+
+import pytest
+
+from craft_cli import messages
+
+
+@pytest.fixture(autouse=True)
+def init_emitter():
+    """Ensure emit is always clean, and initted (in test mode).
+
+    Note that the `init` is done in the current instance that all modules already
+    acquired.
+    """
+    # init with a custom log filepath so user directories are not involved here; note that
+    # we're not using pytest's standard tmp_path as Emitter would write logs there, and in
+    # effect we would be polluting that temporary directory (potentially messing with
+    # tests, that may need that empty), so we use another one.
+    temp_fd, temp_logfile = tempfile.mkstemp(prefix="emitter-logs")
+    os.close(temp_fd)
+    temp_logfile = pathlib.Path(temp_logfile)
+
+    messages.TESTMODE = True
+    messages.emit.init(
+        messages.EmitterMode.QUIET, "test-emitter", "Hello world", log_filepath=temp_logfile
+    )
+    yield
+    # end machinery (just in case it was not ended before; note it's ok to "double end")
+    messages.emit.ended_ok()
+    temp_logfile.unlink()
+
+
+class RegexComparingText(str):
+    """A string that compares for equality using regex.match."""
+
+    def __eq__(self, other):
+        return bool(re.match(self, other, re.DOTALL))
+
+    def __hash__(self):
+        return str.__hash__(self)
+
+
+class RecordingEmitter:
+    """Record what is shown using the emitter and provide a nice API for tests."""
+
+    def __init__(self):
+        self.interactions = []
+        self.paused = False
+
+    @contextlib.contextmanager
+    def pause(self):
+        """Mimics the pause context manager, storing the state to simplify tests."""
+        self.paused = True
+        try:
+            yield
+        finally:
+            self.paused = False
+
+    def record(self, method_name, args, kwargs):
+        """Record the method call and its specific parameters."""
+        self.interactions.append(call(method_name, *args, **kwargs))
+
+    def _check(self, expected_text, method_name, regex, **kwargs):
+        """Really verify messages."""
+        if regex:
+            expected_text = RegexComparingText(expected_text)
+        expected_call = call(method_name, expected_text, **kwargs)
+        for stored_call in self.interactions:
+            if stored_call == expected_call:
+                return stored_call.args[1]
+        raise AssertionError(f"Expected call {expected_call} not found in {self.interactions}")
+
+    def assert_message(self, expected_text, intermediate=None, regex=False):
+        """Check the 'message' method was properly used."""
+        if intermediate is None:
+            return self._check(expected_text, "message", regex)
+        else:
+            return self._check(expected_text, "message", regex, intermediate=intermediate)
+
+    def assert_progress(self, expected_text, regex=False):
+        """Check the 'progress' method was properly used."""
+        return self._check(expected_text, "progress", regex)
+
+    def assert_trace(self, expected_text, regex=False):
+        """Check the 'trace' method was properly used."""
+        return self._check(expected_text, "trace", regex)
+
+    def assert_messages(self, texts):
+        """Check the list of messages (this is helper for a common case of commands results)."""
+        self.assert_interactions([call("message", text) for text in texts])
+
+    def assert_interactions(self, expected_call_list):
+        """Check that the expected call list happen at some point between all stored calls.
+
+        If None is passed, asserts that no message was emitted.
+        """
+        if expected_call_list is None:
+            if self.interactions:
+                show_interactions = "\n".join(map(str, self.interactions))
+                raise AssertionError("Expected no call but really got:\n" + show_interactions)
+            return
+
+        for pos, stored_call in enumerate(self.interactions):
+            if stored_call == expected_call_list[0]:
+                break
+        else:
+            pos = 0
+
+        stored = self.interactions[pos: pos + len(expected_call_list)]
+        assert stored == expected_call_list
+
+
+class RecordingProgresser:
+    def __init__(self, recording_emitter):
+        self.recording_emitter = recording_emitter
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False  # do not consume any exception
+
+    def advance(self, *a, **k):
+        """Record the advance usage."""
+        self.recording_emitter.record("advance", a, k)
+
+
+@pytest.fixture
+def emitter(monkeypatch):
+    """Helper to test everything that was shown using craft-cli Emitter."""
+    recording_emitter = RecordingEmitter()
+    for method_name in ("message", "progress", "trace"):
+        monkeypatch.setattr(
+            messages.emit,
+            method_name,
+            lambda *a, method_name=method_name, **k: recording_emitter.record(method_name, a, k),
+        )
+
+    # progress bar is special, because it also needs to return a context manager with
+    # something that will record progress calls
+    def fake_progress_bar(*a, **k):
+        recording_emitter.record("progress_bar", a, k)
+        return RecordingProgresser(recording_emitter)
+
+    monkeypatch.setattr(messages.emit, "progress_bar", fake_progress_bar)
+
+    # pause is also special, as it's specifically implemented in the recording emitter
+    monkeypatch.setattr(messages.emit, "pause", recording_emitter.pause)
+
+    return recording_emitter

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -125,7 +125,7 @@ Define and use other global arguments
 
 To define more automatic global arguments than the ones provided automatically by ``Dispatcher`` (see :ref:`this explanation <expl_global_args>` for more information), use the ``GlobalArgument`` object to create all you need and pass them to the ``Dispatcher`` at instatiaton time.
 
-Check :class:`its reference <craft_cli.dispatcher.GlobalArgument>` for more information about the parameters needed, but it's very straightforward to create these objects. E.g.::
+Check :class:`craft_cli.dispatcher.GlobalArgument` for more information about the parameters needed, but it's very straightforward to create these objects. E.g.::
 
     ga_sec = GlobalArgument("secure_mode", "flag", "-s", "--secure", "Run the app in secure mode")
     
@@ -142,7 +142,7 @@ The ``dispatcher.pre_parse_args`` method returns the global arguments already pa
 Set a default command in the application
 ========================================
 
-To allow the application to run a command if none was given in the command line, you need to set a default command in the application when instantiating :class:`Dispatcher <craft_cli.dispatcher.Dispatcher>`::
+To allow the application to run a command if none was given in the command line, you need to set a default command in the application when instantiating :class:`craft_cli.dispatcher.Dispatcher`::
 
     dispatcher = Dispatcher(..., default_command=MyImportantCommand)
 
@@ -177,7 +177,7 @@ One of the fixtures (``init_emitter``) is even set with ``autouse=True``, so it 
 
 The other fixture (``emitter``) is very useful to test code interaction with Emitter. It provides an internal recording emitter that has several methods which help to test its usage.
 
-The following example shows a simple usage, please refer to :class:`its reference <craft_cli.pytest_plugin.RecordingEmitter>` for more information about the provided functionality::
+The following example shows a simple usage, please refer to :class:`craft_cli.pytest_plugin.RecordingEmitter` for more information about the provided functionality::
 
     def test_super_function(emitter):
         """Check the super function."""

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -166,3 +166,24 @@ To be able to run another application (in other process) without interfering in 
 When the emitter is paused the terminal is freed, and the emitter does not have control on what happens in the terminal there until it's resumed, not even for logging purposes.
 
 The normal behaviour is resumed when the context manager exits (even if an exception was raised inside).
+
+
+Create unit tests for code that uses Craft CLI Emitter
+======================================================
+
+The library provides two fixtures that simplifies the testing of code using the Emitter when 
+using ``pytest``.
+
+One of the fixtures (``init_emitter``) is even set with ``autouse=True``, so it will 
+automatically initialize the Emitter and tear it down after each test. This way there is 
+nothing special you need to do in your code when testing it, just use it.
+
+The other fixture (``emitter``) is very useful to test code interaction with Emitter. It provides an internal recording emitter that has several methods which help to test its usage.
+
+The following example shows a simple usage, please refer to `its reference <craft_cli.dispatcher.html#craft_cli.pytest_plugin._RecordingEmitter>`_ for more information about the provided functionality::
+
+    def test_super_function(emitter):
+        """Check the super function."""
+        result = super_function(42)
+        assert result == "Secret of life, etc."
+        emitter.assert_trace("Function properly called with magic number.")

--- a/docs/howtos.rst
+++ b/docs/howtos.rst
@@ -125,7 +125,7 @@ Define and use other global arguments
 
 To define more automatic global arguments than the ones provided automatically by ``Dispatcher`` (see :ref:`this explanation <expl_global_args>` for more information), use the ``GlobalArgument`` object to create all you need and pass them to the ``Dispatcher`` at instatiaton time.
 
-Check `its reference <craft_cli.dispatcher.html#craft_cli.dispatcher.GlobalArgument>`_ for more information about the parameters needed, but it's very straightforward to create these objects. E.g.::
+Check :class:`its reference <craft_cli.dispatcher.GlobalArgument>` for more information about the parameters needed, but it's very straightforward to create these objects. E.g.::
 
     ga_sec = GlobalArgument("secure_mode", "flag", "-s", "--secure", "Run the app in secure mode")
     
@@ -142,7 +142,7 @@ The ``dispatcher.pre_parse_args`` method returns the global arguments already pa
 Set a default command in the application
 ========================================
 
-To allow the application to run a command if none was given in the command line, you need to set a default command in the application when instantiating `Dispatcher <craft_cli.dispatcher.html#craft_cli.dispatcher.Dispatcher>`_::
+To allow the application to run a command if none was given in the command line, you need to set a default command in the application when instantiating :class:`Dispatcher <craft_cli.dispatcher.Dispatcher>`::
 
     dispatcher = Dispatcher(..., default_command=MyImportantCommand)
 
@@ -171,16 +171,13 @@ The normal behaviour is resumed when the context manager exits (even if an excep
 Create unit tests for code that uses Craft CLI Emitter
 ======================================================
 
-The library provides two fixtures that simplifies the testing of code using the Emitter when 
-using ``pytest``.
+The library provides two fixtures that simplifies the testing of code using the Emitter when using ``pytest``.
 
-One of the fixtures (``init_emitter``) is even set with ``autouse=True``, so it will 
-automatically initialize the Emitter and tear it down after each test. This way there is 
-nothing special you need to do in your code when testing it, just use it.
+One of the fixtures (``init_emitter``) is even set with ``autouse=True``, so it will automatically initialize the Emitter and tear it down after each test. This way there is nothing special you need to do in your code when testing it, just use it.
 
 The other fixture (``emitter``) is very useful to test code interaction with Emitter. It provides an internal recording emitter that has several methods which help to test its usage.
 
-The following example shows a simple usage, please refer to `its reference <craft_cli.dispatcher.html#craft_cli.pytest_plugin._RecordingEmitter>`_ for more information about the provided functionality::
+The following example shows a simple usage, please refer to :class:`its reference <craft_cli.pytest_plugin.RecordingEmitter>` for more information about the provided functionality::
 
     def test_super_function(emitter):
         """Check the super function."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,12 @@ author_email = snapcraft@lists.snapcraft.io
 license = GNU Lesser General Public License v3 (LGPLv3)
 license_file = LICENSE
 classifiers =
-    Development Status :: 2 - Pre-Alpha
+    Development Status :: 5 - Production/Stable
+    Framework :: Pytest
     Intended Audience :: Developers
     License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
     Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
@@ -75,6 +77,10 @@ dev =
 exclude =
     tests
     tests.*
+
+[options.entry_points]
+pytest11 =
+    mytest = mytest.plugin
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ exclude =
 
 [options.entry_points]
 pytest11 =
-    mytest = mytest.plugin
+    emitter = craft_cli.pytest_plugin
 
 [bdist_wheel]
 universal = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,8 @@
 
 """Generic fixtures for the whole test suite."""
 
-import os
-import pathlib
-import tempfile
-
 import pytest
 
-from craft_cli import messages
 from craft_cli.messages import _Printer, _Spinner
 
 
@@ -74,28 +69,3 @@ def recording_printer(tmp_path):
     yield recording_printer
     if not recording_printer.stopped:
         recording_printer.stop()
-
-
-@pytest.fixture()
-def _init_emitter(monkeypatch):
-    """Ensure emit is always clean, and initted (in test mode).
-
-    Note that the `init` is done in the current instance that all modules already
-    acquired.
-    """
-    # init with a custom log filepath so user directories are not involved here; note that
-    # we're not using pytest's standard tmp_path as Emitter would write logs there, and in
-    # effect we would be polluting that temporary directory (potentially messing with
-    # tests, that may need that empty), so we use another one.
-    temp_fd, temp_logfile = tempfile.mkstemp(prefix="emitter-logs")
-    os.close(temp_fd)
-    temp_logfile = pathlib.Path(temp_logfile)
-
-    monkeypatch.setattr(messages, "TESTMODE", True)
-    messages.emit.init(
-        messages.EmitterMode.QUIET, "test-emitter", "Hello world", log_filepath=temp_logfile
-    )
-    yield
-    # end machinery (just in case it was not ended before; note it's ok to "double end")
-    messages.emit.ended_ok()
-    temp_logfile.unlink()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,207 @@
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Test the fixtures provided by Craft CLI."""
+
+from unittest.mock import call
+
+from craft_cli import messages
+
+import pytest
+
+
+# -- tests for the `init_emitter` auto-fixture
+
+
+def test_initemitter_initiated():
+    """The emitter is initiated."""
+    assert messages.emit._initiated
+    assert not messages.emit._stopped
+
+
+def test_initemitter_testmode():
+    """The messages module is set to test mode."""
+    assert messages.TESTMODE is True
+
+
+def test_initemitter_isolated_tempdir(tmp_path):
+    """The pytest's temp path is not polluted with Emitter logs."""
+    messages.emit.trace("test")
+    assert list(tmp_path.iterdir()) == []
+
+
+# -- tests for the `emitter` fixture
+
+
+def test_emitter_record_message_simple_plain(emitter):
+    """Can verify calls to `message`."""
+    messages.emit.trace("something else we don't care")
+    messages.emit.message("foobar")
+
+    emitter.assert_message("foobar")
+    with pytest.raises(AssertionError):
+        emitter.assert_message("foo")
+
+
+def test_emitter_record_message_intermediate_plain(emitter):
+    """Can verify calls to `message`."""
+    messages.emit.trace("something else we don't care")
+    messages.emit.message("foobar", intermediate=True)
+
+    emitter.assert_message("foobar", intermediate=True)
+    with pytest.raises(AssertionError):
+        emitter.assert_message("foobar")
+    with pytest.raises(AssertionError):
+        emitter.assert_message("foo")
+
+
+def test_emitter_record_progress_plain(emitter):
+    """Can verify calls to `progress`."""
+    messages.emit.trace("something else we don't care")
+    messages.emit.progress("foobar")
+
+    emitter.assert_progress("foobar")
+    with pytest.raises(AssertionError):
+        emitter.assert_progress("foo")
+
+
+def test_emitter_record_trace_plain(emitter):
+    """Can verify calls to `trace`."""
+    messages.emit.progress("something else we don't care")
+    messages.emit.trace("foobar")
+
+    emitter.assert_trace("foobar")
+    with pytest.raises(AssertionError):
+        emitter.assert_trace("foo")
+
+
+def test_emitter_record_message_simple_regex(emitter):
+    """Can verify calls to `message` using a regex."""
+    messages.emit.message("foobar")
+    emitter.assert_message("[fx]oo.*", regex=True)
+
+
+def test_emitter_record_message_intermediate_regex(emitter):
+    """Can verify calls to `message` using a regex."""
+    messages.emit.message("foobar", intermediate=True)
+    emitter.assert_message("[fx]oo.*", intermediate=True, regex=True)
+
+
+def test_emitter_record_progress_regex(emitter):
+    """Can verify calls to `progress` using a regex."""
+    messages.emit.progress("foobar")
+    emitter.assert_progress("[fx]oo.*", regex=True)
+
+
+def test_emitter_record_trace_regex(emitter):
+    """Can verify calls to `trace` using a regex."""
+    messages.emit.trace("foobar")
+    emitter.assert_trace("[fx]oo.*", regex=True)
+
+
+def test_emitter_record_progress_bar_ok(emitter):
+    """Calls to `progress_bar` are recorded."""
+    with messages.emit.progress_bar("title", 20, delta=True) as bar:
+        bar.advance(100)
+    emitter.assert_interactions([
+        call("progress_bar", "title", 20, delta=True),
+        call("advance", 100),
+    ])
+
+
+def test_emitter_record_progress_bar_safe(emitter):
+    """Mocking the progress bar context manager does not hide exceptions."""
+    with pytest.raises(ValueError):
+        with messages.emit.progress_bar("title", 20):
+            raise ValueError()
+
+
+def test_emitter_record_pause(emitter):
+    """Calls to `pause` are recorded."""
+    assert not emitter.paused
+    with messages.emit.pause():
+        assert emitter.paused
+    assert not emitter.paused
+
+
+def test_emitter_messages(emitter):
+    """Can verify several calls to `message`."""
+    for result in range(3):  # simulated bunch of resuls
+        messages.emit.message(f"Got: {result}")
+    emitter.assert_messages([
+        "Got: 0",
+        "Got: 1",
+        "Got: 2",
+    ])
+
+
+def test_emitter_interactions_positive_complete(emitter):
+    """All interactions can be verified, complete."""
+    messages.emit.progress("foo")
+    messages.emit.trace("bar")
+    messages.emit.message("baz")
+
+    emitter.assert_interactions([
+        call("progress", "foo"),
+        call("trace", "bar"),
+        call("message", "baz"),
+    ])
+
+
+def test_emitter_interactions_positive_cross_data(emitter):
+    """All interactions can be verified, crossing elements between calls."""
+    messages.emit.progress("foo")
+    messages.emit.trace("bar")
+    messages.emit.message("baz")
+
+    with pytest.raises(AssertionError):
+        emitter.assert_interactions([
+            call("progress", "bar"),
+        ])
+
+
+def test_emitter_interactions_positive_sequence(emitter):
+    """All interactions can be verified, partial sequence."""
+    messages.emit.progress("foo")
+    messages.emit.trace("bar")
+    messages.emit.message("baz")
+
+    emitter.assert_interactions([
+        call("trace", "bar"),
+        call("message", "baz"),
+    ])
+
+
+def test_emitter_interactions_positive_not_sequence(emitter):
+    """All interactions can be verified, parts not in sequence."""
+    messages.emit.progress("foo")
+    messages.emit.trace("bar")
+    messages.emit.message("baz")
+
+    with pytest.raises(AssertionError):
+        emitter.assert_interactions([
+            call("progress", "foo"),
+            call("message", "baz"),
+        ])
+
+
+def test_emitter_interactions_negative(emitter):
+    """Can verify no interactions."""
+    # nothing emitted!
+    emitter.assert_interactions(None)
+
+    messages.emit.trace("something")
+    with pytest.raises(AssertionError):
+        emitter.assert_interactions(None)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -17,10 +17,9 @@
 
 from unittest.mock import call
 
-from craft_cli import messages
-
 import pytest
 
+from craft_cli import messages
 
 # -- tests for the `init_emitter` auto-fixture
 
@@ -39,7 +38,7 @@ def test_initemitter_testmode():
 def test_initemitter_isolated_tempdir(tmp_path):
     """The pytest's temp path is not polluted with Emitter logs."""
     messages.emit.trace("test")
-    assert list(tmp_path.iterdir()) == []
+    assert not list(tmp_path.iterdir())
 
 
 # -- tests for the `emitter` fixture
@@ -113,12 +112,14 @@ def test_emitter_record_trace_regex(emitter):
 
 def test_emitter_record_progress_bar_ok(emitter):
     """Calls to `progress_bar` are recorded."""
-    with messages.emit.progress_bar("title", 20, delta=True) as bar:
-        bar.advance(100)
-    emitter.assert_interactions([
-        call("progress_bar", "title", 20, delta=True),
-        call("advance", 100),
-    ])
+    with messages.emit.progress_bar("title", 20, delta=True) as progress_bar:
+        progress_bar.advance(100)
+    emitter.assert_interactions(
+        [
+            call("progress_bar", "title", 20, delta=True),
+            call("advance", 100),
+        ]
+    )
 
 
 def test_emitter_record_progress_bar_safe(emitter):
@@ -140,11 +141,13 @@ def test_emitter_messages(emitter):
     """Can verify several calls to `message`."""
     for result in range(3):  # simulated bunch of resuls
         messages.emit.message(f"Got: {result}")
-    emitter.assert_messages([
-        "Got: 0",
-        "Got: 1",
-        "Got: 2",
-    ])
+    emitter.assert_messages(
+        [
+            "Got: 0",
+            "Got: 1",
+            "Got: 2",
+        ]
+    )
 
 
 def test_emitter_interactions_positive_complete(emitter):
@@ -153,11 +156,13 @@ def test_emitter_interactions_positive_complete(emitter):
     messages.emit.trace("bar")
     messages.emit.message("baz")
 
-    emitter.assert_interactions([
-        call("progress", "foo"),
-        call("trace", "bar"),
-        call("message", "baz"),
-    ])
+    emitter.assert_interactions(
+        [
+            call("progress", "foo"),
+            call("trace", "bar"),
+            call("message", "baz"),
+        ]
+    )
 
 
 def test_emitter_interactions_positive_cross_data(emitter):
@@ -167,9 +172,11 @@ def test_emitter_interactions_positive_cross_data(emitter):
     messages.emit.message("baz")
 
     with pytest.raises(AssertionError):
-        emitter.assert_interactions([
-            call("progress", "bar"),
-        ])
+        emitter.assert_interactions(
+            [
+                call("progress", "bar"),
+            ]
+        )
 
 
 def test_emitter_interactions_positive_sequence(emitter):
@@ -178,10 +185,12 @@ def test_emitter_interactions_positive_sequence(emitter):
     messages.emit.trace("bar")
     messages.emit.message("baz")
 
-    emitter.assert_interactions([
-        call("trace", "bar"),
-        call("message", "baz"),
-    ])
+    emitter.assert_interactions(
+        [
+            call("trace", "bar"),
+            call("message", "baz"),
+        ]
+    )
 
 
 def test_emitter_interactions_positive_not_sequence(emitter):
@@ -191,10 +200,12 @@ def test_emitter_interactions_positive_not_sequence(emitter):
     messages.emit.message("baz")
 
     with pytest.raises(AssertionError):
-        emitter.assert_interactions([
-            call("progress", "foo"),
-            call("message", "baz"),
-        ])
+        emitter.assert_interactions(
+            [
+                call("progress", "foo"),
+                call("message", "baz"),
+            ]
+        )
 
 
 def test_emitter_interactions_negative(emitter):

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -29,7 +29,6 @@ from craft_cli.dispatcher import (
 from craft_cli.errors import ArgumentParsingError
 from tests.factory import create_command
 
-
 # --- Tests for the Dispatcher
 
 

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -30,11 +30,6 @@ from craft_cli.errors import ArgumentParsingError
 from tests.factory import create_command
 
 
-@pytest.fixture(autouse=True)
-def init_emitter(_init_emitter):
-    """Enable the init emitter fixture automatically for all this module."""
-
-
 # --- Tests for the Dispatcher
 
 

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -23,7 +23,6 @@ from craft_cli.errors import ArgumentParsingError, ProvideHelpException
 from craft_cli.helptexts import HelpBuilder
 from tests.factory import create_command
 
-
 # -- building "usage" help
 
 

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -24,11 +24,6 @@ from craft_cli.helptexts import HelpBuilder
 from tests.factory import create_command
 
 
-@pytest.fixture(autouse=True)
-def init_emitter(_init_emitter):
-    """Enable the init emitter fixture automatically for all this module."""
-
-
 # -- building "usage" help
 
 

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,11 @@ from craft_cli.errors import CraftError
 from craft_cli.messages import Emitter, EmitterMode, _Handler
 
 FAKE_LOG_NAME = "fakelog.log"
+
+
+@pytest.fixture(autouse=True)
+def init_emitter():
+    """Disable the automatic init emitter fixture for all this module."""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -31,7 +31,7 @@ FAKE_LOG_NAME = "fakelog.log"
 
 @pytest.fixture(autouse=True)
 def init_emitter():
-    """Disable the automatic init emitter fixture for all this module."""
+    """Disable the automatic init emitter fixture for this entire module."""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_messages_printer.py
+++ b/tests/unit/test_messages_printer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,6 +25,11 @@ import pytest
 
 from craft_cli import messages
 from craft_cli.messages import _MessageInfo, _Printer, _Spinner
+
+
+@pytest.fixture(autouse=True)
+def init_emitter():
+    """Disable the automatic init emitter fixture for all this module."""
 
 
 @pytest.fixture

--- a/tests/unit/test_messages_printer.py
+++ b/tests/unit/test_messages_printer.py
@@ -29,7 +29,7 @@ from craft_cli.messages import _MessageInfo, _Printer, _Spinner
 
 @pytest.fixture(autouse=True)
 def init_emitter():
-    """Disable the automatic init emitter fixture for all this module."""
+    """Disable the automatic init emitter fixture for this entire module."""
 
 
 @pytest.fixture


### PR DESCRIPTION
Both are brought from Charmcraft, but here are also tested (as they are not really *used*, but are provided for users of the library).

As these fixtures also work for the project itself (because for development the project itself is installed), I removed the redundant fixture in `conftest.py`. Related to this, instead of enabling that fixture in a couple of test files, in consideration that the "real" `init_emitter` fixture has `autouse=True`, I just turned it off where we didn't want to mess with tests.

Fixes #57.