### PR TITLE
Added the .debug and .verbose methods to Emitter (CRAFT-1137).

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -730,6 +730,38 @@ class Emitter:
         self._printer.show(stream, text, use_timestamp=use_timestamp)  # type: ignore
 
     @_active_guard()
+    def verbose(self, text: str) -> None:
+        """Verbose information.
+
+        Useful to provide more information to the user that shouldn't be exposed
+        when in brief mode for clarity and simplicity.
+        """
+        if self._mode in (EmitterMode.QUIET, EmitterMode.BRIEF):
+            stream = None
+            use_timestamp = False
+        elif self._mode == EmitterMode.VERBOSE:
+            stream = sys.stderr
+            use_timestamp = False
+        else:
+            stream = sys.stderr
+            use_timestamp = True
+        self._printer.show(stream, text, use_timestamp=use_timestamp)  # type: ignore
+
+    @_active_guard()
+    def debug(self, text: str) -> None:
+        """Debug information.
+
+        To record everything that the user may not want to normally see but useful
+        for the app developers to understand why things are failing or performing
+        forensics on the produced logs.
+        """
+        if self._mode in (EmitterMode.QUIET, EmitterMode.BRIEF, EmitterMode.VERBOSE):
+            stream = None
+        else:
+            stream = sys.stderr
+        self._printer.show(stream, text, use_timestamp=True)  # type: ignore
+
+    @_active_guard()
     def trace(self, text: str) -> None:
         """Trace information.
 
@@ -830,7 +862,7 @@ class Emitter:
         # XXX Facundo 2022-06-23: this internal message should mutate to a '.debug' call
         # (when it's available, in the next PRs) so it's properly logged (as in trace it
         # will not reach the logs unless in TRACE mode).
-        self.trace("Emitter: Pausing control of the terminal")
+        self.debug("Emitter: Pausing control of the terminal")
         self._printer.stop()  # type: ignore
         self._stopped = True
         try:
@@ -841,7 +873,7 @@ class Emitter:
             # XXX Facundo 2022-06-23: this internal message should mutate to a '.debug' call
             # (when it's available, in the next PRs) so it's properly logged (as in trace it
             # will not reach the logs unless in TRACE mode).
-            self.trace("Emitter: Resuming control of the terminal")
+            self.debug("Emitter: Resuming control of the terminal")
 
     def _stop(self) -> None:
         """Do all the stopping."""

--- a/examples.py
+++ b/examples.py
@@ -55,13 +55,17 @@ def example_04():
 
 
 def example_05():
-    """Show a debug message when it makes sense."""
-    # note this will show the greeting twice, as it's setting the mode twice (which
-    # won't happen IRL)
+    """Show a verbose/debug/trace messages when it makes sense."""
+    # set _mode directly to avoid the greeting and log messages that appear when using set_mode()
     for mode in EmitterMode:
-        emit.set_mode(mode)
-        time.sleep(0.1)
-        emit.trace(f"Debug message when mode={mode}")
+        emit._mode = mode
+        emit.verbose(f"Verbose message when mode={mode}")
+    for mode in EmitterMode:
+        emit._mode = mode
+        emit.debug(f"Debug message when mode={mode}")
+    for mode in EmitterMode:
+        emit._mode = mode
+        emit.trace(f"Trace message when mode={mode}")
 
 
 def example_06():

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -513,6 +513,85 @@ def test_openstream_in_developer_modes(get_initiated_emitter, mode):
     [
         EmitterMode.QUIET,
         EmitterMode.BRIEF,
+    ],
+)
+def test_verbose_in_quietish_modes(get_initiated_emitter, mode):
+    """Only log the message."""
+    emitter = get_initiated_emitter(mode)
+    emitter.verbose("some text")
+
+    assert emitter.printer_calls == [
+        call().show(None, "some text", use_timestamp=False),
+    ]
+
+
+def test_verbose_in_verbose_mode(get_initiated_emitter):
+    """Log the message and show it in stderr."""
+    emitter = get_initiated_emitter(EmitterMode.VERBOSE)
+    emitter.verbose("some text")
+
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "some text", use_timestamp=False),
+    ]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.DEBUG,
+        EmitterMode.TRACE,
+    ],
+)
+def test_verbose_in_developer_modes(get_initiated_emitter, mode):
+    """Only log the message."""
+    emitter = get_initiated_emitter(mode)
+    emitter.verbose("some text")
+
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "some text", use_timestamp=True),
+    ]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.QUIET,
+        EmitterMode.BRIEF,
+        EmitterMode.VERBOSE,
+    ],
+)
+def test_debug_in_more_quietish_modes(get_initiated_emitter, mode):
+    """Only log the message."""
+    emitter = get_initiated_emitter(mode)
+    emitter.debug("some text")
+
+    assert emitter.printer_calls == [
+        call().show(None, "some text", use_timestamp=True),
+    ]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.DEBUG,
+        EmitterMode.TRACE,
+    ],
+)
+def test_debug_in_developer_modes(get_initiated_emitter, mode):
+    """Only log the message."""
+    emitter = get_initiated_emitter(mode)
+    emitter.debug("some text")
+
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "some text", use_timestamp=True),
+    ]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.QUIET,
+        EmitterMode.BRIEF,
         EmitterMode.VERBOSE,
         EmitterMode.DEBUG,
     ],
@@ -589,6 +668,7 @@ def test_paused_resumed_ok(get_initiated_emitter, tmp_path):
     with emitter.pause():
         assert emitter.printer_calls == [
             # the pausing message is shown and emitter is stopped
+            call().show(None, "Emitter: Pausing control of the terminal", use_timestamp=True),
             call().stop(),
         ]
         emitter.printer_calls.clear()
@@ -597,6 +677,7 @@ def test_paused_resumed_ok(get_initiated_emitter, tmp_path):
     # a new _Printer is created, with same logpath and the resuming message is shown
     assert emitter.printer_calls == [
         call(str(tmp_path / FAKE_LOG_NAME)),
+        call().show(None, "Emitter: Resuming control of the terminal", use_timestamp=True),
     ]
 
 
@@ -608,6 +689,7 @@ def test_paused_resumed_error(get_initiated_emitter, tmp_path):
         with emitter.pause():
             assert emitter.printer_calls == [
                 # the pausing message is shown and emitter is stopped
+                call().show(None, "Emitter: Pausing control of the terminal", use_timestamp=True),
                 call().stop(),
             ]
             emitter.printer_calls.clear()
@@ -619,6 +701,7 @@ def test_paused_resumed_error(get_initiated_emitter, tmp_path):
     # a new _Printer is created, with same logpath and the resuming message is shown
     assert emitter.printer_calls == [
         call(str(tmp_path / FAKE_LOG_NAME)),
+        call().show(None, "Emitter: Resuming control of the terminal", use_timestamp=True),
     ]
 
 

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -399,6 +399,100 @@ def test_progressbar_developer_modes(capsys, mode, monkeypatch):
     [
         EmitterMode.QUIET,
         EmitterMode.BRIEF,
+    ],
+)
+def test_verbose_in_quietish_modes(capsys, mode):
+    """The verbose method in more quietish modes."""
+    emit = Emitter()
+    emit.init(mode, "testapp", GREETING)
+    emit.verbose("The meaning of life is 42.")
+    emit.ended_ok()
+
+    expected = [
+        Line("The meaning of life is 42."),
+    ]
+    assert_outputs(capsys, emit, expected_log=expected)
+
+
+def test_verbose_in_verbose_mode(capsys):
+    """The verbose method in the verbose mode."""
+    emit = Emitter()
+    emit.init(EmitterMode.VERBOSE, "testapp", GREETING)
+    emit.verbose("The meaning of life is 42.")
+    emit.ended_ok()
+
+    expected = [
+        Line("The meaning of life is 42.", timestamp=False),
+    ]
+    assert_outputs(capsys, emit, expected_err=expected, expected_log=expected)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.DEBUG,
+        EmitterMode.TRACE,
+    ],
+)
+def test_verbose_in_developer_modes(capsys, mode):
+    """The verbose method in developer modes."""
+    emit = Emitter()
+    emit.init(mode, "testapp", GREETING)
+    emit.verbose("The meaning of life is 42.")
+    emit.ended_ok()
+
+    expected = [
+        Line("The meaning of life is 42.", timestamp=True),
+    ]
+    assert_outputs(capsys, emit, expected_err=expected, expected_log=expected)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.QUIET,
+        EmitterMode.BRIEF,
+        EmitterMode.VERBOSE,
+    ],
+)
+def test_debug_in_quietish_modes(capsys, mode):
+    """The debug method in more quietish modes."""
+    emit = Emitter()
+    emit.init(mode, "testapp", GREETING)
+    emit.debug("The meaning of life is 42.")
+    emit.ended_ok()
+
+    expected = [
+        Line("The meaning of life is 42."),
+    ]
+    assert_outputs(capsys, emit, expected_log=expected)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.DEBUG,
+        EmitterMode.TRACE,
+    ],
+)
+def test_debug_in_developer_modes(capsys, mode):
+    """The debug method in developer modes."""
+    emit = Emitter()
+    emit.init(mode, "testapp", GREETING)
+    emit.debug("The meaning of life is 42.")
+    emit.ended_ok()
+
+    expected = [
+        Line("The meaning of life is 42.", timestamp=True),
+    ]
+    assert_outputs(capsys, emit, expected_err=expected, expected_log=expected)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        EmitterMode.QUIET,
+        EmitterMode.BRIEF,
         EmitterMode.VERBOSE,
         EmitterMode.DEBUG,
     ],


### PR DESCRIPTION
These two behave ok according to the new Spec.

Also I moved the "pause started" and "pause ended" to be signaled using
internal .debug (now that it's available) as before they will only
appear in the logs if TRACE mode.