### PR TITLE
Improved the _Progresser and how it's used (CRAFT-1139).

### DIFF
--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -426,12 +426,12 @@ def test_progressbar_in_quiet_mode(get_initiated_emitter):
     emitter = get_initiated_emitter(EmitterMode.QUIET)
     progresser = emitter.progress_bar("some text", 5000)
 
-    assert emitter.printer_calls == [
-        call().show(None, "some text", ephemeral=True),
-    ]
+    assert emitter.printer_calls == []
     assert progresser.total == 5000
     assert progresser.text == "some text"
     assert progresser.stream is None
+    assert progresser.use_timestamp is False
+    assert progresser.ephemeral_context is True
 
 
 def test_progressbar_in_brief_mode(get_initiated_emitter):
@@ -439,13 +439,13 @@ def test_progressbar_in_brief_mode(get_initiated_emitter):
     emitter = get_initiated_emitter(EmitterMode.BRIEF)
     progresser = emitter.progress_bar("some text", 5000)
 
-    assert emitter.printer_calls == [
-        call().show(sys.stderr, "some text", ephemeral=True),
-    ]
+    assert emitter.printer_calls == []
     assert progresser.total == 5000
     assert progresser.text == "some text"
     assert progresser.stream == sys.stderr
     assert progresser.delta is True
+    assert progresser.use_timestamp is False
+    assert progresser.ephemeral_context is True
 
 
 def test_progressbar_in_verbose_mode(get_initiated_emitter):
@@ -453,13 +453,13 @@ def test_progressbar_in_verbose_mode(get_initiated_emitter):
     emitter = get_initiated_emitter(EmitterMode.VERBOSE)
     progresser = emitter.progress_bar("some text", 5000)
 
-    assert emitter.printer_calls == [
-        call().show(sys.stderr, "some text", ephemeral=True),
-    ]
+    assert emitter.printer_calls == []
     assert progresser.total == 5000
     assert progresser.text == "some text"
     assert progresser.stream == sys.stderr
     assert progresser.delta is True
+    assert progresser.use_timestamp is False
+    assert progresser.ephemeral_context is False
 
 
 @pytest.mark.parametrize(
@@ -474,13 +474,13 @@ def test_progressbar_in_developer_modes(get_initiated_emitter, mode):
     emitter = get_initiated_emitter(mode)
     progresser = emitter.progress_bar("some text", 5000)
 
-    assert emitter.printer_calls == [
-        call().show(sys.stderr, "some text", ephemeral=True),
-    ]
+    assert emitter.printer_calls == []
     assert progresser.total == 5000
     assert progresser.text == "some text"
     assert progresser.stream == sys.stderr
     assert progresser.delta is True
+    assert progresser.use_timestamp is True
+    assert progresser.ephemeral_context is False
 
 
 def test_progressbar_with_delta_false(get_initiated_emitter):

--- a/tests/unit/test_messages_helpers.py
+++ b/tests/unit/test_messages_helpers.py
@@ -175,13 +175,25 @@ def test_progresser_absolute_mode():
     text = "test text"
     total = 123
     fake_printer = MagicMock()
-    with _Progresser(fake_printer, total, text, stream, delta=False) as progresser:
+    ephemeral = True
+    use_timestamp = True
+    with _Progresser(
+        fake_printer,
+        total,
+        text,
+        stream,
+        delta=False,
+        ephemeral_context=ephemeral,
+        use_timestamp=use_timestamp,
+    ) as progresser:
         progresser.advance(20)
         progresser.advance(30.0)
 
     assert fake_printer.mock_calls == [
-        call.progress_bar(stream, text, 20, total),
-        call.progress_bar(stream, text, 30.0, total),
+        call.show(stream, "test text (--->)", ephemeral=ephemeral, use_timestamp=use_timestamp),
+        call.progress_bar(stream, text, progress=20, total=total, use_timestamp=use_timestamp),
+        call.progress_bar(stream, text, progress=30.0, total=total, use_timestamp=use_timestamp),
+        call.show(stream, "test text (<---)", ephemeral=ephemeral, use_timestamp=use_timestamp),
     ]
 
 
@@ -191,13 +203,25 @@ def test_progresser_delta_mode():
     text = "test text"
     total = 123
     fake_printer = MagicMock()
-    with _Progresser(fake_printer, total, text, stream, delta=True) as progresser:
+    ephemeral = True
+    use_timestamp = True
+    with _Progresser(
+        fake_printer,
+        total,
+        text,
+        stream,
+        delta=True,
+        ephemeral_context=ephemeral,
+        use_timestamp=use_timestamp,
+    ) as progresser:
         progresser.advance(20.5)
         progresser.advance(30)
 
     assert fake_printer.mock_calls == [
-        call.progress_bar(stream, text, 20.5, total),
-        call.progress_bar(stream, text, 50.5, total),
+        call.show(stream, "test text (--->)", ephemeral=ephemeral, use_timestamp=use_timestamp),
+        call.progress_bar(stream, text, progress=20.5, total=total, use_timestamp=use_timestamp),
+        call.progress_bar(stream, text, progress=50.5, total=total, use_timestamp=use_timestamp),
+        call.show(stream, "test text (<---)", ephemeral=ephemeral, use_timestamp=use_timestamp),
     ]
 
 
@@ -205,7 +229,7 @@ def test_progresser_delta_mode():
 def test_progresser_negative_values(delta):
     """The progress cannot be negative."""
     fake_printer = MagicMock()
-    with _Progresser(fake_printer, 123, "test text", sys.stdout, delta=delta) as progresser:
+    with _Progresser(fake_printer, 123, "test text", sys.stdout, delta, True, True) as progresser:
         with pytest.raises(ValueError, match="The advance amount cannot be negative"):
             progresser.advance(-1)
 
@@ -214,7 +238,7 @@ def test_progresser_dont_consume_exceptions():
     """It lets the exceptions go through."""
     fake_printer = MagicMock()
     with pytest.raises(ValueError):
-        with _Progresser(fake_printer, 123, "test text", sys.stdout, delta=True):
+        with _Progresser(fake_printer, 123, "test text", sys.stdout, True, True, True):
             raise ValueError()
 
 

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -277,7 +277,8 @@ def test_progressbar_quiet(capsys):
 
     # nothing to the screen, just to the log
     expected_log = [
-        Line("Uploading stuff"),
+        Line("Uploading stuff (--->)"),
+        Line("Uploading stuff (<---)"),
     ]
     assert_outputs(capsys, emit, expected_log=expected_log)
 
@@ -304,14 +305,16 @@ def test_progressbar_brief_terminal(capsys, monkeypatch):
     emit.ended_ok()
 
     expected_screen = [
-        Line("Uploading stuff", permanent=False),
+        Line("Uploading stuff (--->)", permanent=False),
         Line("Uploading stuff [████████████                    ] 700/1788", permanent=False),
         Line("Uploading stuff [████████████████████████       ] 1400/1788", permanent=False),
         Line("Uploading stuff [███████████████████████████████] 1788/1788", permanent=False),
+        Line("Uploading stuff (<---)", permanent=False),
         Line("And so on", permanent=True),
     ]
     expected_log = [
-        Line("Uploading stuff"),
+        Line("Uploading stuff (--->)"),
+        Line("Uploading stuff (<---)"),
         Line("And so on"),
     ]
     assert_outputs(capsys, emit, expected_err=expected_screen, expected_log=expected_log)
@@ -339,14 +342,16 @@ def test_progressbar_verbose(capsys, monkeypatch):
     emit.ended_ok()
 
     expected_screen = [
-        Line("Uploading stuff", permanent=False),
+        Line("Uploading stuff (--->)", permanent=True),  # this starting line will endure
         Line("Uploading stuff [████████████                    ] 700/1788", permanent=False),
         Line("Uploading stuff [████████████████████████       ] 1400/1788", permanent=False),
         Line("Uploading stuff [███████████████████████████████] 1788/1788", permanent=False),
+        Line("Uploading stuff (<---)", permanent=True),  # this closing line will endure
         Line("And so on", permanent=True),
     ]
     expected_log = [
-        Line("Uploading stuff"),
+        Line("Uploading stuff (--->)"),
+        Line("Uploading stuff (<---)"),
         Line("And so on"),
     ]
     assert_outputs(capsys, emit, expected_err=expected_screen, expected_log=expected_log)
@@ -381,14 +386,16 @@ def test_progressbar_developer_modes(capsys, mode, monkeypatch):
     emit.ended_ok()
 
     expected_screen = [
-        Line("Uploading stuff", permanent=False),
-        Line("Uploading stuff [████████████                    ] 700/1788", permanent=False),
-        Line("Uploading stuff [████████████████████████       ] 1400/1788", permanent=False),
-        Line("Uploading stuff [███████████████████████████████] 1788/1788", permanent=False),
+        Line("Uploading stuff (--->)", permanent=True, timestamp=True),  # this line will endure
+        Line("Uploading stuff [███     ] 700/1788", permanent=False, timestamp=True),
+        Line("Uploading stuff [█████  ] 1400/1788", permanent=False, timestamp=True),
+        Line("Uploading stuff [███████] 1788/1788", permanent=False, timestamp=True),
+        Line("Uploading stuff (<---)", permanent=True, timestamp=True),  # this line will endure
         Line("And so on", permanent=True, timestamp=True),
     ]
     expected_log = [
-        Line("Uploading stuff"),
+        Line("Uploading stuff (--->)"),
+        Line("Uploading stuff (<---)"),
         Line("And so on"),
     ]
     assert_outputs(capsys, emit, expected_err=expected_screen, expected_log=expected_log)


### PR DESCRIPTION
Details:

- it shows messages with timestamps when needed

- it marks the beginning and end of the progress in general (very useful for example for logs, where the *progress itself* is not recorded)

- as that context info is responsibility of the class itself, there is no more a separate message before putting it to work.

Also added support in the Printer to show the timestamp for the progress bar, if indicated.