### PR TITLE
Behave as 'captured output' when the (fake) terminal has zero columns (CRAFT-1128).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_cli
-	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access,duplicate-code,too-many-lines
+	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access,duplicate-code,too-many-lines,missing-class-docstring,too-few-public-methods
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -55,7 +55,8 @@ from craft_cli import errors
 
 @lru_cache
 def _stream_is_terminal(stream: Union[TextIO, None]) -> bool:
-    return getattr(stream, "isatty", lambda: False)()
+    is_a_terminal = getattr(stream, "isatty", lambda: False)()
+    return is_a_terminal and _get_terminal_width() > 0
 
 
 @dataclass

--- a/tests/unit/test_messages_printer.py
+++ b/tests/unit/test_messages_printer.py
@@ -70,6 +70,49 @@ def test_terminal_width():
     assert messages._get_terminal_width() == shutil.get_terminal_size().columns
 
 
+def test_streamisterminal_no_isatty_method():
+    """The stream does not have an isatty method."""
+    stream = object()
+    assert not hasattr(stream, "isatty")
+    result = messages._stream_is_terminal(stream)
+    assert result is False
+
+
+def test_streamisterminal_tty_not():
+    """The stream is not a terminal."""
+
+    class FakeStream:
+        def isatty(self):
+            return False
+
+    result = messages._stream_is_terminal(FakeStream())
+    assert result is False
+
+
+def test_streamisterminal_tty_yes_usable(monkeypatch):
+    """The stream is a terminal of use."""
+    monkeypatch.setattr(messages, "_get_terminal_width", lambda: 40)
+
+    class FakeStream:
+        def isatty(self):
+            return True
+
+    result = messages._stream_is_terminal(FakeStream())
+    assert result is True
+
+
+def test_streamisterminal_tty_yes_unusable(monkeypatch):
+    """The stream is a terminal that cannot really be used (no columns!)."""
+    monkeypatch.setattr(messages, "_get_terminal_width", lambda: 0)
+
+    class FakeStream:
+        def isatty(self):
+            return True
+
+    result = messages._stream_is_terminal(FakeStream())
+    assert result is False
+
+
 # -- tests for the writing line (terminal version) function
 
 


### PR DESCRIPTION
The fix can be tested IRL by using `expect` with the following script:
```
set stty_init "rows 100 cols 0"
spawn env/bin/python examples.py 1
expect "The meaning of life is 42."
```