### PR TITLE
Close pipes when the thread ends

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -612,6 +612,8 @@ class _PipeReaderThread(threading.Thread):
         if _WINDOWS_MODE:
             os.write(self.write_pipe, self.UNBLOCK_BYTE)
         self.join()
+        os.close(self.read_pipe)
+        os.close(self.write_pipe)
 
 
 class _StreamContextManager:

--- a/tests/unit/test_messages_stream_cm.py
+++ b/tests/unit/test_messages_stream_cm.py
@@ -204,7 +204,7 @@ def test_pipereader_chunk_assembler(recording_printer, monkeypatch):
 
 
 def test_no_fail_if_big_number_is_used(recording_printer):
-    """Ensures that all the resources are freed on exit."""
+    """Ensures that opening and closing a big number of objects doesn't fail."""
     # The limit is 1024 both in Linux and BSD, but each object opens two FDs
     for counter in range(514):
         print(counter, end="\r")  # just to use the variable
@@ -213,3 +213,14 @@ def test_no_fail_if_big_number_is_used(recording_printer):
         prt.stop()
 
     assert True
+
+
+def test_ensure_pipes_are_closed(recording_printer):
+    """Ensures that all the resources are freed on exit."""
+    prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
+    prt.start()
+    prt.stop()
+    with pytest.raises(Exception):
+        os.fstat(prt.read_pipe)
+    with pytest.raises(Exception):
+        os.fstat(prt.write_pipe)

--- a/tests/unit/test_messages_stream_cm.py
+++ b/tests/unit/test_messages_stream_cm.py
@@ -201,3 +201,15 @@ def test_pipereader_chunk_assembler(recording_printer, monkeypatch):
     msg1, msg2 = recording_printer.written_terminal_lines
     assert msg1.text == ":: ------abcde---"
     assert msg2.text == ":: otherline---"
+
+
+def test_no_fail_if_big_number_is_used(recording_printer):
+    """Ensures that all the resources are freed on exit."""
+    # The limit is 1024 both in Linux and BSD, but each object opens two FDs
+    for counter in range(514):
+        print(counter, end="\r")  # just to use the variable
+        prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
+        prt.start()
+        prt.stop()
+
+    assert True

--- a/tests/unit/test_messages_stream_cm.py
+++ b/tests/unit/test_messages_stream_cm.py
@@ -220,7 +220,9 @@ def test_ensure_pipes_are_closed(recording_printer):
     prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
     prt.start()
     prt.stop()
-    with pytest.raises(Exception):
+    with pytest.raises(OSError) as err:
         os.fstat(prt.read_pipe)
-    with pytest.raises(Exception):
+    assert err.value.errno == 9
+    with pytest.raises(OSError) as err:
         os.fstat(prt.write_pipe)
+    assert err.value.errno == 9


### PR DESCRIPTION
The _PipeReaderThread() class creates two pipes to manage input/output, and uses SELECT() to know when there is data to be read. Unfortunately, those two pipes aren't closed when the thread ends, which means that the FDs of the pipes of new classes will grow up and up. The problem is that SELECT has a limit in the FD value that can monitor, usually 1024, which means that any FD with a value greater than that can't be monitored by it, and will show the error if tried to:

`  ValueError: filedescriptor out of range in select()`

With small snaps this is not a problem because they don't create so many objects of this kind as to reach the limit, but with very big snaps (like Gnome-42-2204-SDK, with more than 50 binaries), it can be achieved.

This MR partially fixes this by closing the FDs when the thread ends. Anyway, the best solution is to also use POLL instead of SELECT, because it doesn't have that limit (this is implemented in https://github.com/canonical/craft-cli/pull/104 , which should be merged along this one).

fix https://github.com/canonical/craft-cli/issues/102

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
