### PR TITLE
Use poll instead of select

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -506,14 +506,17 @@ class _PipeReaderThread(threading.Thread):
 
     def _run_posix(self) -> None:
         """Run the thread, handling pipes in the POSIX way."""
+        poller = select.poll()
+        poller.register(self.read_pipe, select.POLLIN)
         while True:
-            rlist, _, _ = select.select([self.read_pipe], [], [], 0.1)
-            if rlist:
+            rlist = poller.poll(0.1)
+            if len(rlist) != 0:
                 data = os.read(self.read_pipe, _PIPE_READER_CHUNK_SIZE)
                 self._write(data)
             elif self.stop_flag:
                 # only quit when nothing left to read
                 break
+        poller.unregister(self.read_pipe)
 
     def _run_windows(self) -> None:
         """Run the thread, handling pipes in the Windows way."""


### PR DESCRIPTION
This patch ensures that there is no risk of reaching FD_SETSIZE
in a pipe FD. That would prevent select to run and would return
an error:

  ValueError: filedescriptor out of range in select()

This patch is complementary to

  https://github.com/canonical/craft-cli/pull/103

and both should be applied to fully fix the bug.

Fix https://github.com/canonical/craft-cli/issues/102

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
