### PR TITLE
Fix unitary tests in local

### DIFF
--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -31,6 +31,8 @@ from tests.factory import create_command
 
 # --- Tests for the Dispatcher
 
+emit.init(EmitterMode.DEBUG, "testappname", "greeter")
+
 
 def test_dispatcher_help_init():
     """Init the help infrastructure properly."""


### PR DESCRIPTION
When running "make test-units" from a shell, several tests fail
with the error:

`  RuntimeError: Emitter needs to be initiated first`

This patch fixes this by initializing the 'emit' object.

Fix https://github.com/canonical/craft-cli/issues/105

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
