### PR TITLE
Generalized the custom argument parsing, and fixed two exceptions in the process

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -241,7 +241,7 @@ class Dispatcher:  # pylint: disable=too-many-instance-attributes
         return help_text
 
     def _build_usage_exc(self, text):
-        """Buiold an ArgumentParsingError exception with the usage message from the given text."""
+        """Build an ArgumentParsingError exception with the usage message from the given text."""
         raise ArgumentParsingError(self._help_builder.get_usage_message(text))
 
     def _get_requested_help(self, parameters):

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -14,6 +14,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
+import textwrap
 from unittest.mock import patch
 
 import pytest
@@ -285,8 +286,13 @@ def test_dispatcher_generic_setup_verbosity_levels_wrong():
     dispatcher = Dispatcher("appname", groups)
     with pytest.raises(ArgumentParsingError) as err:
         dispatcher.pre_parse_args(["--verbosity", "yelling", "somecommand"])
-    assert str(err.value) == (
-        "Bad verbosity level; valid values are 'quiet', 'brief', 'verbose', 'debug' and 'trace'."
+    assert str(err.value) == textwrap.dedent(
+        """\
+        Usage: appname [options] command [args]...
+        Try 'appname -h' for help.
+
+        Error: Bad verbosity level; valid values are 'quiet', 'brief', 'verbose', 'debug' and 'trace'.
+    """
     )
 
 
@@ -324,8 +330,13 @@ def test_dispatcher_generic_setup_mutually_exclusive(options):
     dispatcher = Dispatcher("appname", groups)
     with pytest.raises(ArgumentParsingError) as err:
         dispatcher.pre_parse_args(options)
-    assert str(err.value) == (
-        "The 'verbose', 'quiet' and 'verbosity' options are mutually exclusive."
+    assert str(err.value) == textwrap.dedent(
+        """\
+        Usage: appname [options] command [args]...
+        Try 'appname -h' for help.
+
+        Error: The 'verbose', 'quiet' and 'verbosity' options are mutually exclusive.
+    """
     )
 
 
@@ -367,7 +378,14 @@ def test_dispatcher_generic_setup_paramglobal_without_param_simple(options):
     dispatcher = Dispatcher("appname", groups, extra_global_args=[extra])
     with pytest.raises(ArgumentParsingError) as err:
         dispatcher.pre_parse_args(options)
-    assert str(err.value) == "The 'globalparam' option expects one argument."
+    assert str(err.value) == textwrap.dedent(
+        """\
+        Usage: appname [options] command [args]...
+        Try 'appname -h' for help.
+
+        Error: The 'globalparam' option expects one argument.
+    """
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As part of the "help with markdown output" work I needed to generalize the custom argument parsing, and found that we were raising errors without the proper "usage format" in a couple of cases. Fixed that.
