### PR TITLE
Return the exception, not raise it.

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -242,7 +242,7 @@ class Dispatcher:  # pylint: disable=too-many-instance-attributes
 
     def _build_usage_exc(self, text):
         """Build an ArgumentParsingError exception with the usage message from the given text."""
-        raise ArgumentParsingError(self._help_builder.get_usage_message(text))
+        return ArgumentParsingError(self._help_builder.get_usage_message(text))
 
     def _get_requested_help(
         self, parameters


### PR DESCRIPTION
The returned exception is always raised where the function is called.