### PR TITLE
(messages) Show messages from subprocess in an ephemeral way when in brief mode. (CRAFT-1542)

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -652,7 +652,7 @@ class _StreamContextManager:
         printer_flags = {
             "use_timestamp": use_timestamp,
             "ephemeral": ephemeral_mode,
-            "end_line": not ephemeral_mode
+            "end_line": not ephemeral_mode,
         }
 
         # show the intended text (explicitly asking for a complete line) before passing the

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -649,11 +649,11 @@ class _StreamContextManager:
     ):
         # prepare the printer flags for the initial message and everything produced
         # by the pipe reader
-        printer_flags = {"use_timestamp": use_timestamp}
-        if ephemeral_mode:
-            printer_flags.update(ephemeral=True, end_line=False)
-        else:
-            printer_flags.update(ephemeral=False, end_line=True)
+        printer_flags = {
+            "use_timestamp": use_timestamp,
+            "ephemeral": ephemeral_mode,
+            "end_line": not ephemeral_mode
+        }
 
         # show the intended text (explicitly asking for a complete line) before passing the
         # output command to the pip-reading thread

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -47,6 +47,7 @@ import platformdirs
 
 try:
     import win32pipe  # type: ignore
+    import win32security  # type: ignore
 
     _WINDOWS_MODE = True
 except ImportError:
@@ -544,7 +545,9 @@ class _PipeReaderThread(threading.Thread):
             # ignoring the type of the first parameter below, as documentation allows to use None
             # to make it use a NULL security descriptor:
             #     https://www.markjour.com/docs/pywin32-docs/PySECURITY_ATTRIBUTES.html
-            self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(None, 0, binary_mode)  # type: ignore
+            # self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(None, 0, binary_mode)  # type: ignore
+            sec_attrib = win32security.SECURITY_ATTRIBUTES()
+            self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(sec_attrib, 0, binary_mode)
         else:
             self.read_pipe, self.write_pipe = os.pipe()
 

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -47,7 +47,6 @@ import platformdirs
 
 try:
     import win32pipe  # type: ignore
-    import win32security  # type: ignore
 
     _WINDOWS_MODE = True
 except ImportError:
@@ -545,9 +544,7 @@ class _PipeReaderThread(threading.Thread):
             # ignoring the type of the first parameter below, as documentation allows to use None
             # to make it use a NULL security descriptor:
             #     https://www.markjour.com/docs/pywin32-docs/PySECURITY_ATTRIBUTES.html
-            # self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(None, 0, binary_mode)  # type: ignore
-            sec_attrib = win32security.SECURITY_ATTRIBUTES()
-            self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(sec_attrib, 0, binary_mode)
+            self.read_pipe, self.write_pipe = win32pipe.FdCreatePipe(None, 0, binary_mode)  # type: ignore
         else:
             self.read_pipe, self.write_pipe = os.pipe()
 

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -612,7 +612,6 @@ class _PipeReaderThread(threading.Thread):
 
             if data:
                 self._write(data)
-            time.sleep(0.1)
 
     def run(self) -> None:
         """Run the thread."""

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -346,7 +346,9 @@ The last column of the table though is not about the screen: it indicates if the
        | without progress
    * - ``.open_stream(...)``
      - --
-     - --
+     - | stderr
+       | transient (*)
+       | plain
      - | stderr
        | permanent
        | plain

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1288,6 +1288,6 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
     # raising it because CIs are slower (a limit that is still useful: when
     # subprocess Python is run without the `-u` option average delays are around 500 ms.
     delays = [t_outside - t_inside for t_outside, t_inside in timestamps]
-    too_big = [delay for delay in delays if delay > 0.200]
+    too_big = [delay for delay in delays if delay > 0.300]
     if too_big:
         pytest.fail(f"Delayed capture: {too_big} avg delay is {sum(delays) / len(delays):.3f}")

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1268,7 +1268,7 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
         )
     )
     emit = Emitter()
-    emit.init(EmitterMode.BRIEF, "testapp", GREETING)
+    emit.init(EmitterMode.QUIET, "testapp", GREETING)
     with emit.open_stream("Testing stream") as stream:
         cmd = [sys.executable, "-u", script]
         subprocess.run(cmd, stdout=stream, check=True)

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1232,7 +1232,6 @@ def _parse_timestamp(text):
     return tstamp
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Temporary skip, need to investigate why slow")
 @pytest.mark.parametrize(
     "loops, sleep, max_repetitions",
     [
@@ -1264,7 +1263,7 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
             tstamp = datetime.now().isoformat(sep=" ", timespec="milliseconds")
             print(tstamp, "short text to repeat " * random.randint(1, {max_repetitions}))
             time.sleep({sleep})
-    """
+        """
         )
     )
     emit = Emitter()

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1232,6 +1232,7 @@ def _parse_timestamp(text):
     return tstamp
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Temporary skip, need to investigate why slow")
 @pytest.mark.parametrize(
     "loops, sleep, max_repetitions",
     [

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -684,15 +684,8 @@ def test_trace_in_trace_mode(capsys):
     assert_outputs(capsys, emit, expected_err=expected, expected_log=expected)
 
 
-@pytest.mark.parametrize(
-    "mode",
-    [
-        EmitterMode.QUIET,
-        EmitterMode.BRIEF,
-    ],
-)
 @pytest.mark.parametrize("output_is_terminal", [True, False])
-def test_third_party_output_quietish_modes(capsys, tmp_path, mode):
+def test_third_party_output_quiet(capsys, tmp_path):
     """Manage the streams produced for sub-executions, more quiet modes."""
     # something to execute
     script = tmp_path / "script.py"
@@ -706,7 +699,7 @@ def test_third_party_output_quietish_modes(capsys, tmp_path, mode):
         )
     )
     emit = Emitter()
-    emit.init(mode, "testapp", GREETING)
+    emit.init(EmitterMode.QUIET, "testapp", GREETING)
     with emit.open_stream("Testing stream") as stream:
         subprocess.run([sys.executable, script], stdout=stream, stderr=stream, check=True)
     emit.ended_ok()
@@ -717,6 +710,70 @@ def test_third_party_output_quietish_modes(capsys, tmp_path, mode):
         Line(":: foobar err"),
     ]
     assert_outputs(capsys, emit, expected_log=expected)
+
+
+@pytest.mark.parametrize("output_is_terminal", [True])
+def test_third_party_output_brief_terminal(capsys, tmp_path):
+    """Manage the streams produced for sub-executions, brief mode, to the terminal."""
+    # something to execute
+    script = tmp_path / "script.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+        import sys
+        print("foobar out", flush=True)
+        print("foobar err", file=sys.stderr, flush=True)
+    """
+        )
+    )
+    emit = Emitter()
+    emit.init(EmitterMode.BRIEF, "testapp", GREETING)
+    with emit.open_stream("Testing stream") as stream:
+        subprocess.run([sys.executable, script], stdout=stream, stderr=stream, check=True)
+    emit.ended_ok()
+
+    expected_err = [
+        Line("Testing stream", permanent=False),
+        Line(":: foobar out", permanent=False),
+        Line(":: foobar err", permanent=False),
+        # This cleaner line is inserted by the printer stop
+        # sequence to reset the last ephemeral print to terminal.
+        Line("", permanent=False),
+    ]
+    expected_log = [
+        Line("Testing stream"),
+        Line(":: foobar out"),
+        Line(":: foobar err"),
+    ]
+    assert_outputs(capsys, emit, expected_err=expected_err, expected_log=expected_log)
+
+
+@pytest.mark.parametrize("output_is_terminal", [False])
+def test_third_party_output_brief_captured(capsys, tmp_path):
+    """Manage the streams produced for sub-executions, brief mode, captured."""
+    # something to execute
+    script = tmp_path / "script.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+        import sys
+        print("foobar out", flush=True)
+        print("foobar err", file=sys.stderr, flush=True)
+    """
+        )
+    )
+    emit = Emitter()
+    emit.init(EmitterMode.BRIEF, "testapp", GREETING)
+    with emit.open_stream("Testing stream") as stream:
+        subprocess.run([sys.executable, script], stdout=stream, stderr=stream, check=True)
+    emit.ended_ok()
+
+    expected = [
+        Line("Testing stream"),
+        Line(":: foobar out"),
+        Line(":: foobar err"),
+    ]
+    assert_outputs(capsys, emit, expected_err=expected, expected_log=expected)
 
 
 @pytest.mark.parametrize("output_is_terminal", [True, False])
@@ -1168,18 +1225,21 @@ def test_logging_after_closing(capsys, logger):
 def _parse_timestamp(text):
     """Parse a timestamp from its text format to seconds from epoch."""
     date_and_time, msec = text.strip().split(".")
-    dt = datetime.strptime(date_and_time, "%Y-%m-%d %H:%M:%S")
-    tstamp = dt.timestamp()
+    dt_ = datetime.strptime(date_and_time, "%Y-%m-%d %H:%M:%S")
+    tstamp = dt_.timestamp()
     assert len(msec) == 3
     tstamp += int(msec) / 1000
     return tstamp
 
 
-@pytest.mark.parametrize("loops, sleep, max_repetitions", [
-    (100, .01, 30),
-    (1000, .001, 100),
-    (10, .1, 2),
-])
+@pytest.mark.parametrize(
+    "loops, sleep, max_repetitions",
+    [
+        (100, 0.01, 30),
+        (1000, 0.001, 100),
+        (10, 0.1, 2),
+    ],
+)
 @pytest.mark.parametrize("output_is_terminal", [True, False])
 def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
     """Check that there are no noticeable delays when capturing output.
@@ -1214,7 +1274,7 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
     emit.ended_ok()
 
     timestamps = []
-    with open(emit._log_filepath, "rt", encoding="utf8") as filehandler:
+    with open(emit._log_filepath, "rt", encoding="utf8") as filehandler:  # type: ignore
         for line in filehandler:
             match = re.match(rf"({TIMESTAMP_FORMAT}):: ({TIMESTAMP_FORMAT}).*\n", line)
             if not match:

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1288,6 +1288,6 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
     # raising it because CIs are slower (a limit that is still useful: when
     # subprocess Python is run without the `-u` option average delays are around 500 ms.
     delays = [t_outside - t_inside for t_outside, t_inside in timestamps]
-    too_big = [delay for delay in delays if delay > 0.050]
+    too_big = [delay for delay in delays if delay > 0.200]
     if too_big:
         pytest.fail(f"Delayed capture: {too_big} avg delay is {sum(delays) / len(delays):.3f}")

--- a/tests/unit/test_messages_integration.py
+++ b/tests/unit/test_messages_integration.py
@@ -1288,6 +1288,6 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
     # raising it because CIs are slower (a limit that is still useful: when
     # subprocess Python is run without the `-u` option average delays are around 500 ms.
     delays = [t_outside - t_inside for t_outside, t_inside in timestamps]
-    too_big = [delay for delay in delays if delay > 0.300]
+    too_big = [delay for delay in delays if delay > 0.050]
     if too_big:
         pytest.fail(f"Delayed capture: {too_big} avg delay is {sum(delays) / len(delays):.3f}")

--- a/tests/unit/test_messages_stream_cm.py
+++ b/tests/unit/test_messages_stream_cm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -51,7 +51,11 @@ def force_terminal_behaviour(monkeypatch):
 def test_streamcm_init_silent(recording_printer):
     """Check the context manager bootstrapping with no stream."""
     scm = _StreamContextManager(
-        recording_printer, "initial text", stream=None, use_timestamp=False
+        recording_printer,
+        "initial text",
+        stream=None,
+        use_timestamp=False,
+        ephemeral_mode=False,
     )
 
     # no initial message
@@ -68,7 +72,11 @@ def test_streamcm_init_silent(recording_printer):
 def test_streamcm_init_with_stream(recording_printer, stream):
     """Check the context manager bootstrapping with a stream."""
     scm = _StreamContextManager(
-        recording_printer, "initial text", stream=stream, use_timestamp=False
+        recording_printer,
+        "initial text",
+        stream=stream,
+        use_timestamp=False,
+        ephemeral_mode=False,
     )
 
     # initial message
@@ -92,7 +100,11 @@ def test_streamcm_init_with_stream(recording_printer, stream):
 def test_streamcm_init_with_stream_and_timestamp(recording_printer, stream):
     """Check the context manager bootstrapping with a stream and a timestamp."""
     scm = _StreamContextManager(
-        recording_printer, "initial text", stream=stream, use_timestamp=True
+        recording_printer,
+        "initial text",
+        stream=stream,
+        use_timestamp=True,
+        ephemeral_mode=False,
     )
 
     # initial message
@@ -112,10 +124,42 @@ def test_streamcm_init_with_stream_and_timestamp(recording_printer, stream):
     assert not scm.pipe_reader.is_alive()
 
 
+@pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
+def test_streamcm_init_with_stream_ephemeral(recording_printer, stream):
+    """Check the context manager bootstrapping with a stream in ephemeral mode."""
+    scm = _StreamContextManager(
+        recording_printer,
+        "initial text",
+        stream=stream,
+        use_timestamp=False,
+        ephemeral_mode=True,
+    )
+
+    # initial message
+    (msg,) = recording_printer.written_terminal_lines  # pylint: disable=unbalanced-tuple-unpacking
+    assert msg.stream == stream
+    assert msg.text == "initial text"
+    assert msg.use_timestamp is False
+    assert msg.end_line is False
+    assert msg.ephemeral is True
+    assert msg.bar_progress is None
+    assert msg.bar_total is None
+
+    # check it used the pipe reader correctly
+    assert isinstance(scm.pipe_reader, _PipeReaderThread)
+    assert scm.pipe_reader.printer == recording_printer
+    assert scm.pipe_reader.stream == stream
+    assert not scm.pipe_reader.is_alive()
+
+
 def test_streamcm_usage_lifecycle(recording_printer):
     """Enters and exits the context manager correctly."""
     scm = _StreamContextManager(
-        recording_printer, "initial text", stream=None, use_timestamp=False
+        recording_printer,
+        "initial text",
+        stream=None,
+        use_timestamp=False,
+        ephemeral_mode=False,
     )
 
     with scm as context_manager:
@@ -131,7 +175,11 @@ def test_streamcm_dont_consume_exceptions(recording_printer):
     """It lets the exceptions go through."""
     with pytest.raises(ValueError):
         with _StreamContextManager(
-            recording_printer, "initial text", stream=None, use_timestamp=False
+            recording_printer,
+            "initial text",
+            stream=None,
+            use_timestamp=False,
+            ephemeral_mode=False,
         ):
             raise ValueError()
 
@@ -142,7 +190,8 @@ def test_streamcm_dont_consume_exceptions(recording_printer):
 @pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
 def test_pipereader_simple(recording_printer, stream):
     """Basic pipe reader usage."""
-    prt = _PipeReaderThread(recording_printer, stream, use_timestamp=False)
+    flags = dict(use_timestamp=False, ephemeral=False, end_line=True)
+    prt = _PipeReaderThread(recording_printer, stream, flags)
     prt.start()
     os.write(prt.write_pipe, b"123\n")
     prt.stop()
@@ -160,7 +209,8 @@ def test_pipereader_simple(recording_printer, stream):
 @pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
 def test_pipereader_with_timestamp(recording_printer, stream):
     """Basic pipe reader usage with a timestamp."""
-    prt = _PipeReaderThread(recording_printer, stream, use_timestamp=True)
+    flags = dict(use_timestamp=True, ephemeral=False, end_line=True)
+    prt = _PipeReaderThread(recording_printer, stream, flags)
     prt.start()
     os.write(prt.write_pipe, b"123\n")
     prt.stop()
@@ -175,10 +225,30 @@ def test_pipereader_with_timestamp(recording_printer, stream):
     assert msg.bar_total is None
 
 
+@pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
+def test_pipereader_ephemeral(recording_printer, stream):
+    """Basic pipe reader usage in ephemeral moede."""
+    flags = dict(use_timestamp=False, ephemeral=True, end_line=False)
+    prt = _PipeReaderThread(recording_printer, stream, flags)
+    prt.start()
+    os.write(prt.write_pipe, b"123\n")
+    prt.stop()
+
+    (msg,) = recording_printer.written_terminal_lines  # pylint: disable=unbalanced-tuple-unpacking
+    assert msg.stream == stream
+    assert msg.text == ":: 123"  # unicode, with the prefix, and without the newline
+    assert msg.use_timestamp is False
+    assert msg.end_line is False
+    assert msg.ephemeral is True
+    assert msg.bar_progress is None
+    assert msg.bar_total is None
+
+
 def test_pipereader_chunk_assembler(recording_printer, monkeypatch):
     """Converts ok arbitrary chunks to lines."""
     monkeypatch.setattr(messages, "_PIPE_READER_CHUNK_SIZE", 5)
-    prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
+    flags = dict(use_timestamp=False, ephemeral=False, end_line=True)
+    prt = _PipeReaderThread(recording_printer, sys.stdout, flags)
     prt.start()
 
     # write different chunks, sleeping in the middle not for timing, but to let the
@@ -205,10 +275,10 @@ def test_pipereader_chunk_assembler(recording_printer, monkeypatch):
 
 def test_no_fail_if_big_number_is_used(recording_printer):
     """Ensures that opening and closing a big number of objects doesn't fail."""
+    flags = dict(use_timestamp=False, ephemeral=False, end_line=True)
     # The limit is 1024 both in Linux and BSD, but each object opens two FDs
-    for counter in range(514):
-        print(counter, end="\r")  # just to use the variable
-        prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
+    for _ in range(514):
+        prt = _PipeReaderThread(recording_printer, sys.stdout, flags)
         prt.start()
         prt.stop()
 
@@ -217,7 +287,8 @@ def test_no_fail_if_big_number_is_used(recording_printer):
 
 def test_ensure_pipes_are_closed(recording_printer):
     """Ensures that all the resources are freed on exit."""
-    prt = _PipeReaderThread(recording_printer, sys.stdout, use_timestamp=False)
+    flags = dict(use_timestamp=False, ephemeral=False, end_line=True)
+    prt = _PipeReaderThread(recording_printer, sys.stdout, flags)
     prt.start()
     prt.stop()
     with pytest.raises(OSError) as err:


### PR DESCRIPTION
Also added an example to show this (and improved the whole examples machinery to accept parameters, to make it easier to use).

Added a couple of small changes because pyright/pylint, and will split the big `messages.py` in a following branch (without semantic changes in it).

Documentation updated.

No change needed from the applications using the library.