### PR TITLE
fix new printer for logging handler

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -615,7 +615,7 @@ class Emitter:
             yield
         finally:
             self._stopped = False
-            self._printer = Printer(self._log_filepath)  # type: ignore
+            self._printer = self._log_handler.printer = Printer(self._log_filepath)  # type: ignore
             self.debug("Emitter: Resuming control of the terminal")
 
     def _stop(self) -> None:


### PR DESCRIPTION
I'm not sure if this is the best solution here or we should use something like `printer.start` / `printer.recreate`.
I also think some unit tests would be nice and will add them if this solution is approved.

fixes: #139 