### PR TITLE
messages: replace tabs with spaces in open_stream()

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -221,6 +221,9 @@ class _PipeReaderThread(threading.Thread):
 
             # write the useful line to intended outputs
             unicode_line = useful_line.decode("utf8")
+            # replace tabs with a set number of spaces so that the printer
+            # can correctly count the characters.
+            unicode_line = unicode_line.replace("\t", "  ")
             text = f":: {unicode_line}"
             self.printer.show(self.stream, text, **self.printer_flags)
 

--- a/tests/unit/test_messages_stream_cm.py
+++ b/tests/unit/test_messages_stream_cm.py
@@ -244,6 +244,19 @@ def test_pipereader_ephemeral(recording_printer, stream):
     assert msg.bar_total is None
 
 
+@pytest.mark.parametrize("stream", [sys.stdout, sys.stderr])
+def test_pipereader_tabs(recording_printer, stream):
+    """Check that tabs are converted to spaces."""
+    flags = {"use_timestamp": False, "ephemeral": False, "end_line": True}
+    prt = _PipeReaderThread(recording_printer, stream, flags)
+    prt.start()
+    os.write(prt.write_pipe, b"\t123\t456\n")
+    prt.stop()
+
+    (msg,) = recording_printer.written_terminal_lines  # pylint: disable=unbalanced-tuple-unpacking
+    assert msg.text == "::   123  456"  # tabs expanded into 2 spaces
+
+
 def test_pipereader_chunk_assembler(recording_printer, monkeypatch):
     """Converts ok arbitrary chunks to lines."""
     monkeypatch.setattr(messages, "_PIPE_READER_CHUNK_SIZE", 5)


### PR DESCRIPTION
The tabs complicate the internal book-keeping because "\t12" has 3 characters but is printed to the terminal with a varying number of spaces (depending on the user's tabwidth). For the pipe reader used in open_stream(), this issue manifested as a bug where lines containing tabs would result in multiple lines being printed (instead of just the last one), which breaks the "ephemeral" aspect of the stream.

Note that this discovery implies that we should probably revisit this tab issue in more places; in particular, the Printer does multiple comparisons between the len() of the text and the terminal width, so if the text has tabs that comparison will be incorrect. However, this commit aims only to fix the (unreleased) behavior of showing subprocess output as ephemeral messages inside open_stream().

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Part of CRAFT-1797
