### PR TITLE
tools: call 'coverage' directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,8 @@ xfail_strict = true
 
 [tool.coverage.run]
 branch = true
-parallel = true
+# Disable parallel coverage to preserve the data-file name so that 'coverage xml' finds it
+parallel = false
 omit = ["tests/**"]
 
 [tool.coverage.report]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,12 @@ base = testenv, test
 description = Run unit tests with pytest
 labels =
     py38, py310, py311: tests, unit-tests
-commands = pytest {tty:--color=yes} --cov --cov-report=xml:results/coverage-{env_name}.xml --junit-xml=results/test-results-{env_name}.xml tests/unit {posargs}
+commands =
+    # NOTE: we use `coverage` directly here instead of pytest-cov because the loading of the
+    # pytest plugin provided by craft-cli means that some code gets imported *before*
+    # pytest-cov gets started, and those lines are marked as misses.
+    coverage run --source craft_cli -m pytest {tty:--color=yes} --junit-xml=results/test-results-{env_name}.xml tests/unit {posargs}
+    coverage xml -o results/coverage-{env_name}.xml
 
 [testenv:integration-{py38,py39,py310,py311,py312}]
 base = testenv, test


### PR DESCRIPTION
The problem: when using pytest-cov to integrate coverage with the test
run, there is a 'race' between pytest-cov and the pytest plugin provided
by craft-cli (the emitter). When craft-cli's plugin is loaded first, it
necessitates importing the main 'craft_cli' package, which in turn
imports dispatcher.py, messages.py, etc.
    
As a result, all the top-level lines (class and function definitions,
global-variables, etc) are loaded _before_ coverage starts running,
meaning that they are marked as 'hits' because they are never "loaded
again" during the tests. Instead, use coverage specifically so that
it's always set-up before the whole importing starts.
