### PR TITLE
type: change CommandGroup.commands from List to Sequence

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -17,7 +17,7 @@
 
 import argparse
 import difflib
-from typing import Any, Dict, List, Literal, NamedTuple, Optional, Tuple, Type
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence, Tuple, Type
 
 from craft_cli import EmitterMode, emit
 from craft_cli.errors import ArgumentParsingError, ProvideHelpException
@@ -35,7 +35,7 @@ class CommandGroup(NamedTuple):
     """
 
     name: str
-    commands: List[Type["BaseCommand"]]
+    commands: Sequence[Type["BaseCommand"]]
 
 
 class GlobalArgument(NamedTuple):


### PR DESCRIPTION
List is invariant, whereas sequence is covariant. Since CommandGroup always wants subclasses, we should use Sequence

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
