### PR TITLE
docs: document class attributes separately

### DIFF
--- a/craft_cli/__init__.py
+++ b/craft_cli/__init__.py
@@ -14,7 +14,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-"""Interact with Canonical services such as Charmhub and the Snap Store."""
+"""A Command Line Client builder."""
 
 try:
     from ._version import __version__

--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -29,33 +29,35 @@ class CommandGroup(NamedTuple):
 
     A list of these is what is passed to the ``Dispatcher`` to run commands as part
     of the application.
-
-    :param name: identifier of the command group (to be used in help texts).
-    :param commands: a list of the commands in this group.
     """
 
     name: str
+    """The identifier of the command group (to be used in help texts)."""
+
     commands: Sequence[Type["BaseCommand"]]
+    """A list of the commands belonging in this group."""
 
 
 class GlobalArgument(NamedTuple):
-    """Definition of a global argument to be handled by the Dispatcher.
-
-    :param name: identifier of the argument (the reference in the dictionary returned
-        by ``Dispatcher.pre_parse_args`` method)
-    :param type: the argument type: ``flag`` for arguments that are set to ``True`` if
-        specified (``False`` by default), or ``option`` if a value is needed after it.
-    :param short_option: the short form of the argument (a dash with a letter, e.g. ``-s``); it can
-        be None if the option does not have a short form.
-    :param long_option: the long form of the argument (two dashes and a name, e.g. ``--secure``).
-    :param help_message: the one-line text that describes the argument, for building the help texts.
-    """
+    """Definition of a global argument to be handled by the Dispatcher."""
 
     name: str
+    """Identifier of the argument (the reference in the dictionary returned) by the
+      ``Dispatcher.pre_parse_args()`` method)"""
+
     type: Literal["flag", "option"]
+    """The argument type: ``flag`` for arguments that are set to ``True`` if specified
+      (``False`` by default), or ``option`` if a value is needed after it."""
+
     short_option: Optional[str]
+    """The short form of the argument (a dash with a letter, e.g. ``-s``); it can be None
+      if the option does not have a short form."""
+
     long_option: str
+    """The long form of the argument (two dashes and a name, e.g. ``--secure``)."""
+
     help_message: str
+    """the one-line text that describes the argument, for building the help texts."""
 
 
 _DEFAULT_GLOBAL_ARGS = [
@@ -93,34 +95,33 @@ _DEFAULT_GLOBAL_ARGS = [
 class BaseCommand:
     """Base class to build application commands.
 
-    Subclass this to create a new command; the subclass must define the following attributes:
+    Subclass this to create a new command; the subclass must define the ``name``,
+    ``help_msg``, and ``overview`` attributes. Additionally, it may override the
+    ``common`` and ``hidden`` attributes to change from their default values.
 
-    - name: the identifier in the command line
-
-    - help_msg: a one line help for user documentation
-
-    - overview: a longer multi-line text with the whole command description
-
-    Also it may override the following one to change its default:
-
-    - common: if it's a common/starter command, which are prioritized in the help (default to
-      False)
-
-    - hidden: do not show in help texts, useful for aliases or deprecated commands (default
-      to False)
-
-    It also must/can override some methods for the proper command behaviour (see each
+    The subclass may also override some methods for the proper command behaviour (see each
     method's docstring).
 
-    The subclass must be declared in the corresponding section of command groups indicated
-    to the Dispatcher.
+    Finally, the subclass must be declared in the corresponding section of command groups
+    indicated to the Dispatcher.
     """
 
     name: str
+    """The identifier in the command line, like "build" or "pack"."""
+
     help_msg: str
+    """A one-line help message for user documentation."""
+
     overview: str
-    common = False
-    hidden = False
+    """Longer, multi-line text with the whole command description."""
+
+    common: bool = False
+    """Whether this is a common/starter command, which are prioritized in the help
+      (defaults to False)."""
+
+    hidden: bool = False
+    """Do not show in help texts, useful for aliases or deprecated commands (defaults
+      to False)."""
 
     def __init__(self, config: Optional[Dict[str, Any]]):
         self.config = config
@@ -140,6 +141,8 @@ class BaseCommand:
         global ones (see `main.Dispatcher._build_argument_parser`).
 
         If this method is not overridden, the command will not have any parameters.
+
+        :param parser: The object to fill with this command's parameters.
         """
 
     def run(self, parsed_args: argparse.Namespace) -> Optional[int]:
@@ -147,9 +150,8 @@ class BaseCommand:
 
         It must be overridden by the command implementation.
 
-        This will receive parsed arguments that were defined in :meth:.fill_parser.
-
-        It should return None or the desired process' return code.
+        :param parsed_args: The parsed arguments that were defined in :meth:`fill_parser`.
+        :return: This method should return ``None`` or the desired process' return code.
         """
         raise NotImplementedError()
 

--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -24,29 +24,33 @@ from typing import Optional
 
 
 class CraftError(Exception):
-    """Signal a program error with a lot of information to report.
+    """Signal a program error with a lot of information to report."""
 
-    :ivar message: the main message to the user, to be shown as first line (and
-      probably only that, according to the different modes); note that in some
-      cases the log location will be attached to this message.
+    message: str
+    """The main message to the user, to be shown as first line (and probably only that,
+      according to the different modes); note that in some cases the log location will be
+      attached to this message."""
 
-    :ivar details: the full error details received from a third party which
-      originated the error situation
+    details: Optional[str]
+    """The full error details received from a third party which originated the error
+      situation."""
 
-    :ivar resolution: an extra line indicating to the user how the error may be
-      fixed or avoided (to be shown together with 'message')
+    resolution: Optional[str]
+    """An extra line indicating to the user how the error may be fixed or avoided (to be
+      shown together with ``message``)."""
 
-    :ivar docs_url: an URL to point the user to documentation (to be shown
-      together with 'message')
+    docs_url: Optional[str]
+    """An URL to point the user to documentation (to be shown together with ``message``)."""
 
-    :ivar logpath_report: if the location of the log filepath should be presented
-      in the screen as the final message
+    logpath_report: bool
+    """Whether the location of the log filepath should be presented in the screen as the
+     final message."""
 
-    :ivar reportable: if an error report should be sent to some error-handling
-      backend (like Sentry)
+    reportable: bool
+    """If an error report should be sent to some error-handling backend (like Sentry)."""
 
-    :ivar retcode: the code to return when the application finishes
-    """
+    retcode: int
+    """The code to return when the application finishes."""
 
     def __init__(
         self,

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -45,8 +45,8 @@ except ImportError:
 from craft_cli import errors
 from craft_cli.printer import Printer
 
-# the different modes the Emitter can be set
 EmitterMode = enum.Enum("EmitterMode", "QUIET BRIEF VERBOSE DEBUG TRACE")
+"""The different modes the Emitter can be set."""
 
 # the limit to how many log files to have
 _MAX_LOG_FILES = 5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx-pydantic",
     "sphinx_toolbox",
-    "sphinx_toolbox.more_autodoc",
-    "sphinx.ext.autodoc",  # Must be loaded after more_autodoc
+    "sphinx.ext.autodoc",
 ]
 
 templates_path = ["_templates"]
@@ -69,6 +68,9 @@ typehints_document_rtype = True
 github_username = "canonical"
 github_repository = "craft-cli"
 # endregion
+
+# Document class properties before public methods
+autodoc_member_order = "bysource"
 
 
 # region Setup reference generation


### PR DESCRIPTION
Instead of keeping their docs in the main class docstring, use per- attribute docstrings to improve the readibility and "searchability" of the items. Some minor tweaks and adjustments to the text itself, but nothing too major.

Note that we also drop the "sphinx.ext.more_autodoc" extension because it isn't adding anything (that I can tell) other than an annoying double list of init parameters that I couldn't get rid of.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

CRAFT-1180