### PR TITLE
format: allow use "R|" for raw text

### DIFF
--- a/craft_cli/helptexts.py
+++ b/craft_cli/helptexts.py
@@ -63,7 +63,11 @@ def _build_item_plain(title: str, text: str, title_space: int) -> List[str]:
     # the first 4 spaces, the two spaces to separate title/text, and the ':'
     not_title_space = 7
     text_space = TERMINAL_WIDTH - title_space - not_title_space
-    wrapped_lines = textwrap.wrap(text, text_space)
+    raw_text = text.startswith("R|")
+    if raw_text:
+        wrapped_lines = text[2:].splitlines()
+    else:
+        wrapped_lines = textwrap.wrap(text, text_space)
 
     # first line goes with the title at column 4
     first = f"    {title:>{title_space}s}:  {wrapped_lines[0]}"
@@ -71,7 +75,10 @@ def _build_item_plain(title: str, text: str, title_space: int) -> List[str]:
 
     # the rest (if any) still aligned but without title
     for line in wrapped_lines[1:]:
-        result.append(" " * (title_space + not_title_space) + line)
+        if raw_text:
+            result.append(line)
+        else:
+            result.append(" " * (title_space + not_title_space) + line)
 
     return result
 
@@ -353,7 +360,11 @@ class HelpBuilder:
             "|-|-|",
         ]
         for title, text in options:
-            option_lines.append(f"| `{title}` | {text} |")
+            if text.startswith("R|"):
+                _text = text[2:].replace("\n", "<br>")
+            else:
+                _text = text.replace("\n", "<br>")
+            option_lines.append(f"| `{title}` | {_text} |")
 
         textblocks.append("\n".join(option_lines))
 

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -1237,6 +1237,55 @@ def test_helprequested_specific_command():
     assert args[2] == OutputFormat.plain
 
 
+def test_helprequested_with_raw_help_text():
+    """Requested help for a command."""
+    raw_text = """R|test raw text
+    This is a raw text
+    that is very long
+    and has several lines
+
+    with some blank lines
+
+        and spaces
+    """
+
+    def fill_parser(self, parser):  # pylint: disable=unused-argument
+        parser.add_argument("--choice", choices=[1, 2, 3], help=raw_text)
+
+    cmd = create_command("somecmd", "Some command with multiline help.")
+    cmd.fill_parser = fill_parser
+
+    command_groups = [CommandGroup("group", [cmd])]
+    dispatcher = Dispatcher("testapp", command_groups)
+
+    parameters = ["somecmd"]
+    assert dispatcher._get_requested_help(parameters) == (
+        """\
+Usage:
+    testapp somecmd [options]
+
+Summary:
+
+Options:
+       -h, --help:  Show this help message and exit
+    -v, --verbose:  Show debug information and be more verbose
+      -q, --quiet:  Only show warnings and errors, not progress
+      --verbosity:  Set the verbosity level to 'quiet', 'brief',
+                    'verbose', 'debug' or 'trace'
+         --choice:  test raw text
+    This is a raw text
+    that is very long
+    and has several lines
+
+    with some blank lines
+
+        and spaces
+
+For a summary of all commands, run 'testapp help --all'.
+"""
+    )
+
+
 @pytest.mark.parametrize(
     "parameters",
     [


### PR DESCRIPTION
Help text starts with "R|" will not be reformatted.