### PR TITLE
emitter: add "streaming brief" feature

### DIFF
--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -199,7 +199,7 @@ class Printer:
 
         if message.use_timestamp:
             timestamp_str = message.created_at.isoformat(sep=" ", timespec="milliseconds")
-            text = timestamp_str + " " + text
+            text = f"{timestamp_str} {text}"
 
         if spintext:
             # forced to overwrite the previous message to present the spinner

--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -53,6 +53,7 @@ class _MessageInfo:  # pylint: disable=too-many-instance-attributes
     use_timestamp: bool = False
     end_line: bool = False
     created_at: datetime = field(default_factory=datetime.now)
+    terminal_prefix: str = ""
 
 
 @lru_cache
@@ -161,19 +162,44 @@ class Printer:
         # keep account of output terminal streams with unfinished lines
         self.unfinished_stream: Optional[TextIO] = None
 
+        self.terminal_prefix = ""
+
         # run the spinner supervisor
         self.spinner = _Spinner(self)
         if not TESTMODE:
             self.spinner.start()
 
+    def set_terminal_prefix(self, prefix: str) -> None:
+        """Set the string to be prepended to every message shown to the terminal."""
+        self.terminal_prefix = prefix
+
+    def _get_prefixed_message_text(self, message: _MessageInfo) -> str:
+        """Get the message's text with the proper terminal prefix, if any."""
+        text = message.text
+        prefix = message.terminal_prefix
+
+        # Don't repeat text: can happen due to the spinner.
+        if prefix and text != prefix:
+            separator = ":: "
+
+            # Don't duplicate the separator, which can come from multiple different
+            # sources.
+            if text.startswith(separator):
+                separator = ""
+
+            text = f"{prefix} {separator}{text}"
+
+        return text
+
     def _write_line_terminal(self, message: _MessageInfo, *, spintext: str = "") -> None:
         """Write a simple line message to the screen."""
         # prepare the text with (maybe) the timestamp
+
+        text = self._get_prefixed_message_text(message)
+
         if message.use_timestamp:
             timestamp_str = message.created_at.isoformat(sep=" ", timespec="milliseconds")
-            text = timestamp_str + " " + message.text
-        else:
-            text = message.text
+            text = timestamp_str + " " + text
 
         if spintext:
             # forced to overwrite the previous message to present the spinner
@@ -330,6 +356,7 @@ class Printer:
             ephemeral=ephemeral,
             use_timestamp=use_timestamp,
             end_line=end_line,
+            terminal_prefix=self.terminal_prefix,
         )
         self._show(msg)
         if not avoid_logging:

--- a/examples.py
+++ b/examples.py
@@ -451,6 +451,41 @@ def example_28(mode_name, total_messages=10):
     _run_noisy_subprocess(mode_name, total_messages, example_test_sub_app)
 
 
+def example_29(mode_name, streaming_brief):
+    """Support some library logging."""
+    logger = logging.getLogger()
+    logger.setLevel(0)
+
+    mode = EmitterMode[mode_name.upper()]
+    emit.init(mode, "example_29", "Hi", streaming_brief=bool(int(streaming_brief)))
+
+    emit.progress(f"Mode set to {mode}", permanent=True)
+
+    emit.progress("Starting up lib1", permanent=False)
+    _call_lib(logger, 1)
+    emit.progress("Finished lib1", permanent=True)
+
+    emit.progress("Starting up lib2", permanent=False)
+    _call_lib(logger, 2)
+    emit.progress("Finished lib2", permanent=True)
+
+    emit.progress("Starting up lib3", permanent=False)
+    _call_lib(logger, 3)
+    emit.progress("Finished lib3", permanent=True)
+
+
+def _call_lib(logger, index):
+    lib = f"lib{index}"
+
+    time.sleep(2)
+    logger.info(f"   {lib} INFO 1")
+    logger.debug(f"   {lib} DEBUG 1")
+    time.sleep(2)
+    logger.info(f"   {lib} INFO 2")
+    logger.debug(f"   {lib} DEBUG 2")
+    time.sleep(2)
+
+
 # -- end of test cases
 
 if len(sys.argv) < 2:
@@ -463,7 +498,8 @@ if func is None:
     print(f"ERROR: function {name!r} not found")
     exit()
 
-emit.init(EmitterMode.BRIEF, "explorator", "Greetings earthlings")
+if int(sys.argv[1]) != 29:
+    emit.init(EmitterMode.BRIEF, "explorator", "Greetings earthlings")
 try:
     func(*sys.argv[2:])
 except CraftError as err:

--- a/tests/unit/test_messages_helpers.py
+++ b/tests/unit/test_messages_helpers.py
@@ -291,7 +291,7 @@ def test_handler_emit_full_message(handler):
     logging.getLogger().error("test message %s", 23)
 
     assert handler.printer.mock_calls == [
-        call.show(sys.stderr, "test message 23", use_timestamp=False),
+        call.show(sys.stderr, "test message 23", use_timestamp=False, ephemeral=False),
     ]
 
 
@@ -307,10 +307,10 @@ def test_handler_emit_quiet(handler):
     logger.log(5, "test custom sub-debug")
 
     assert handler.printer.mock_calls == [
-        call.show(None, "test error", use_timestamp=False),
-        call.show(None, "test warning", use_timestamp=False),
-        call.show(None, "test info", use_timestamp=False),
-        call.show(None, "test debug", use_timestamp=False),
+        call.show(None, "test error", use_timestamp=False, ephemeral=False),
+        call.show(None, "test warning", use_timestamp=False, ephemeral=False),
+        call.show(None, "test info", use_timestamp=False, ephemeral=False),
+        call.show(None, "test debug", use_timestamp=False, ephemeral=False),
     ]
 
 
@@ -326,10 +326,10 @@ def test_handler_emit_brief(handler):
     logger.log(5, "test custom sub-debug")
 
     assert handler.printer.mock_calls == [
-        call.show(None, "test error", use_timestamp=False),
-        call.show(None, "test warning", use_timestamp=False),
-        call.show(None, "test info", use_timestamp=False),
-        call.show(None, "test debug", use_timestamp=False),
+        call.show(None, "test error", use_timestamp=False, ephemeral=False),
+        call.show(None, "test warning", use_timestamp=False, ephemeral=False),
+        call.show(None, "test info", use_timestamp=False, ephemeral=False),
+        call.show(None, "test debug", use_timestamp=False, ephemeral=False),
     ]
 
 
@@ -345,10 +345,10 @@ def test_handler_emit_verbose(handler):
     logger.log(5, "test custom sub-debug")
 
     assert handler.printer.mock_calls == [
-        call.show(sys.stderr, "test error", use_timestamp=False),
-        call.show(sys.stderr, "test warning", use_timestamp=False),
-        call.show(sys.stderr, "test info", use_timestamp=False),
-        call.show(None, "test debug", use_timestamp=False),
+        call.show(sys.stderr, "test error", use_timestamp=False, ephemeral=False),
+        call.show(sys.stderr, "test warning", use_timestamp=False, ephemeral=False),
+        call.show(sys.stderr, "test info", use_timestamp=False, ephemeral=False),
+        call.show(None, "test debug", use_timestamp=False, ephemeral=False),
     ]
 
 
@@ -364,10 +364,10 @@ def test_handler_emit_debug(handler):
     logger.log(5, "test custom sub-debug")
 
     assert handler.printer.mock_calls == [
-        call.show(sys.stderr, "test error", use_timestamp=True),
-        call.show(sys.stderr, "test warning", use_timestamp=True),
-        call.show(sys.stderr, "test info", use_timestamp=True),
-        call.show(sys.stderr, "test debug", use_timestamp=True),
+        call.show(sys.stderr, "test error", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test warning", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test info", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test debug", use_timestamp=True, ephemeral=False),
     ]
 
 
@@ -383,11 +383,11 @@ def test_handler_emit_trace(handler):
     logger.log(5, "test custom sub-debug")
 
     assert handler.printer.mock_calls == [
-        call.show(sys.stderr, "test error", use_timestamp=True),
-        call.show(sys.stderr, "test warning", use_timestamp=True),
-        call.show(sys.stderr, "test info", use_timestamp=True),
-        call.show(sys.stderr, "test debug", use_timestamp=True),
-        call.show(sys.stderr, "test custom sub-debug", use_timestamp=True),
+        call.show(sys.stderr, "test error", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test warning", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test info", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test debug", use_timestamp=True, ephemeral=False),
+        call.show(sys.stderr, "test custom sub-debug", use_timestamp=True, ephemeral=False),
     ]
 
 


### PR DESCRIPTION
This commit adds a new feature to the Emitter, tentatively called "streaming brief". It is initially disabled, and can be enabled in the Emitter's init() call.

Once enabled, the feature will leverage the "multi-action" nature of progress() calls to "stream", in a single line, info-level log messages and text written to the open_stream()'s pipe. For example, the following sequence of calls in BRIEF mode:

```
emit.progress("Starting stage 1", permanent=False) ...
log.info("Doing first step")
...
log.info("Doing second step")
...
emit.progress("Finished stage 1", permanent=True)
```

... will cause the two 'info' messages to "stream" on the terminal, prefixed by "Starting stage 1 ::" to indicate that they are related to that progress message. All these three messages are ephemeral which means that in the end only the final progress() call will be visible on the terminal.

Fixes #165

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
