### PR TITLE
fix(dispatcher): revert a change in return type annotation

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
-from typing import Any, Literal, NamedTuple, NoReturn, Sequence
+from typing import Any, Literal, NamedTuple, NoReturn, Optional, Sequence
 
 from craft_cli import EmitterMode, emit
 from craft_cli.errors import ArgumentParsingError, ProvideHelpException
@@ -147,7 +147,11 @@ class BaseCommand:
         :param parser: The object to fill with this command's parameters.
         """
 
-    def run(self, parsed_args: argparse.Namespace) -> int | None:
+    # NOTE: run() returns `Optional[int]` instead of `int | None` as the latter would
+    # be a breaking change for subclasses that override this with just `None` and
+    # use the `overrides.override` decorator. See:
+    # https://github.com/mkorpela/overrides/issues/115
+    def run(self, parsed_args: argparse.Namespace) -> Optional[int]:  # noqa: UP007
         """Execute command's actual functionality.
 
         It must be overridden by the command implementation.


### PR DESCRIPTION
Commit b0698f9 changed the type annotation for the return value of BaseCommand.run() from `Optional[int]` to the semantically-equivalent preferred notation `int | None`.

However, this is a breaking change in the case of subclasses that override this method, return only `None` and use the `override` decorator from non-latest versions of the `override` package, as those versions do not realize that `None` is a valid subset of `int | None`.

Although the fix in client code is simple, the original commit was not meant to break client code at all. Therefore, revert this specific change until we are ready to release a new major version.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
