### PR TITLE
feat: add secrets API

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -735,6 +735,11 @@ class Emitter:
         self._report_error(error)
         self._stop()
 
+    @_active_guard()
+    def set_secrets(self, secrets: list[str]) -> None:
+        """Set the list of strings that should be masked out in all output."""
+        self._printer.set_secrets(secrets)
+
 
 # module-level instantiated Emitter; this is the instance all code shall use and Emitter
 # shall not be instantiated again for the process' run

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -1123,3 +1123,100 @@ def test_spinner_silent_on_complete_messages(spinner, monkeypatch):
     time.sleep(0.05)
 
     assert spinner.printer.spinned == []
+
+
+def test_secrets(capsys, log_filepath):
+    printer = Printer(log_filepath)
+
+    secrets = ["banana", "watermelon"]
+
+    message = "apple banana orange watermelon"
+    expected = "apple ***** orange *****\n"
+
+    printer.set_secrets(secrets)
+    printer.show(sys.stderr, message, avoid_logging=True)
+
+    _, stderr = capsys.readouterr()
+    assert stderr == expected
+
+
+def test_secrets_copy(capsys, log_filepath):
+    printer = Printer(log_filepath)
+
+    secrets = ["banana", "watermelon"]
+
+    message = "apple banana orange watermelon"
+    expected = "apple ***** orange *****\n" * 2
+
+    printer.set_secrets(secrets)
+    printer.show(sys.stderr, message, avoid_logging=True)
+
+    # Modify the client-side list to make sure it doesn't affect
+    # the printer
+    secrets.pop(0)
+    printer.show(sys.stderr, message, avoid_logging=True)
+
+    _, stderr = capsys.readouterr()
+    assert stderr == expected
+
+
+def test_secrets_log(log_filepath):
+    printer = Printer(log_filepath)
+
+    secrets = ["banana", "watermelon"]
+
+    message = "apple banana orange watermelon"
+    expected = "apple ***** orange *****\n"
+
+    printer.set_secrets(secrets)
+    printer.show(None, message, use_timestamp=False)
+
+    # Chop off the timestamp
+    obtained = log_filepath.read_text()
+    start = obtained.find("apple")
+
+    assert obtained[start:] == expected
+
+
+def test_secrets_progress_bar(capsys, log_filepath, monkeypatch):
+    stream = sys.stderr
+    monkeypatch.setattr(stream, "isatty", lambda: True)
+    printer = Printer(log_filepath)
+
+    secrets = ["banana", "watermelon"]
+
+    message = "apple banana orange watermelon"
+    expected = "apple ***** orange *****"
+
+    printer.set_secrets(secrets)
+    printer.progress_bar(stream, message, progress=0.0, total=1.0, use_timestamp=False)
+
+    _, stderr = capsys.readouterr()
+    assert stderr.startswith(expected)
+
+
+def test_secrets_terminal_prefix(capsys, log_filepath, monkeypatch):
+    stream = sys.stderr
+    monkeypatch.setattr(stream, "isatty", lambda: True)
+    printer = Printer(log_filepath)
+
+    message = "apple banana orange watermelon"
+
+    # Set secrets first, then prefix
+    printer.set_secrets(["watermelon"])
+    printer.set_terminal_prefix("banana watermelon")
+    printer.show(stream, message)
+
+    # Set prefix first, then secrets
+    printer.set_terminal_prefix("watermelon banana")
+    printer.set_secrets(["banana"])
+    printer.show(stream, message)
+
+    expected = [
+        "banana ***** :: apple banana orange *****",
+        "watermelon ***** :: apple ***** orange watermelon",
+    ]
+
+    _, stderr = capsys.readouterr()
+    obtained = [l.strip() for l in stderr.splitlines()]
+    assert obtained == expected


### PR DESCRIPTION
The public API consists of a single method, `Emitter.set_secrets()`, that receives a list of strings and causes said strings to be masked by "*****" in every output generated by the emitter's printer. This includes regular emitter messages, messages generated by log calls, spinner, progress bar and the "streaming brief" prefix.

Fixes #184

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
