### PR TITLE
fix: clear prefix for message() and error()

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -523,6 +523,9 @@ class Emitter:
         Normally used as the final message, to show the result of a command.
         """
         stream = None if self._mode == EmitterMode.QUIET else sys.stdout
+        if self._streaming_brief:
+            # Clear the message prefix, as this message stands alone
+            self._printer.set_terminal_prefix("")
         self._printer.show(stream, text)
 
     @_active_guard()
@@ -733,6 +736,9 @@ class Emitter:
     @_active_guard(ignore_when_stopped=True)
     def error(self, error: errors.CraftError) -> None:
         """Handle the system's indicated error and stop machinery."""
+        if self._streaming_brief:
+            # Clear the message prefix, as this error stands alone
+            self._printer.set_terminal_prefix("")
         self._report_error(error)
         self._stop()
 

--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -216,6 +216,11 @@ class Printer:
         elif self.prv_msg.ephemeral:
             # the last one was ephemeral, overwrite it
             maybe_cr = "\r"
+            if self.prv_msg.stream != message.stream:
+                # If the last message's stream is different from this new one,
+                # send the carriage return to the original stream only.
+                print(maybe_cr, flush=True, file=self.prv_msg.stream, end="")
+                maybe_cr = ""
         else:
             # complete the previous line, leaving that message ok
             maybe_cr = ""

--- a/tests/integration/test_messages_integration.py
+++ b/tests/integration/test_messages_integration.py
@@ -1307,6 +1307,34 @@ def test_capture_delays(tmp_path, loops, sleep, max_repetitions):
 
 
 @pytest.mark.parametrize("output_is_terminal", [True])
+def test_progress_and_message(capsys, logger):
+    emit = Emitter()
+    emit.init(EmitterMode.BRIEF, "testapp", GREETING)
+    emit.progress("The meaning of life is 42.")
+    emit.progress("Another message.")
+    emit.message("Finished successfully.")
+    emit.ended_ok()
+
+    expected_term = [
+        Line("The meaning of life is 42.", permanent=False),
+        Line("Another message.", permanent=False),
+    ]
+    expected_out = [Line("Finished successfully.", permanent=True)]
+    expected_log = [
+        Line("The meaning of life is 42.", permanent=False),
+        Line("Another message.", permanent=False),
+        Line("Finished successfully.", permanent=False),
+    ]
+    assert_outputs(
+        capsys,
+        emit,
+        expected_err=expected_term,
+        expected_out=expected_out,
+        expected_log=expected_log,
+    )
+
+
+@pytest.mark.parametrize("output_is_terminal", [True])
 def test_streaming_brief(capsys, logger):
     """Test the overall behavior of the "streaming_brief" feature regarding the terminal
     and the generated logs."""


### PR DESCRIPTION
The first commit fixes a bug I bumped into where an `emit.progress()` followed by an `emit.message()` would send the carriage return (to clear the ephemeral progress) to the wrong stream. The second commit then does the actual clearing of the prefix.

Fixes #202
