### PR TITLE
chore(deps): drop Pydantic dependency

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -13,7 +13,6 @@ sphinx-tabs
 sphinxcontrib-jquery
 sphinxext-opengraph
 # Extra, craft-cli-specific requirements for the docs
-sphinx-pydantic==0.1.1
 sphinx-toolbox==3.5.0
 sphinx-lint==0.9.0
 pytest>=7.0.0 # This is just because this is imported by the code

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -129,7 +129,6 @@ custom_extensions = [
     "sphinx.ext.doctest",
     "sphinx_design",
     "sphinx_copybutton",
-    "sphinx-pydantic",
     "sphinx.ext.autodoc",
     "sphinx_toolbox",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 dependencies = [
     "platformdirs",
-    "pydantic",
     "pyyaml",
     "pywin32; sys_platform == 'win32'"
 ]


### PR DESCRIPTION
We don't use the library at all - probably what happened is that we copied the deps from somewhere else.

Fixes #201

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
