### PR TITLE
fix: handle errors when decoding bytes from subprocesses

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -239,8 +239,9 @@ class _PipeReaderThread(threading.Thread):
             useful_line = data[pointer:newline_position]
             pointer = newline_position + 1
 
-            # write the useful line to intended outputs
-            unicode_line = useful_line.decode("utf8")
+            # write the useful line to intended outputs. Decode with errors="replace"
+            # here because we don't know where this line is coming from.
+            unicode_line = useful_line.decode("utf8", errors="replace")
             # replace tabs with a set number of spaces so that the printer
             # can correctly count the characters.
             unicode_line = unicode_line.replace("\t", "  ")


### PR DESCRIPTION
Since these bytes come from the output of unknown processes, there is no guarantee that they are valid utf-8 text. We also have no way to know what encoding they have (if any), so the best we can do is replace the invalid bytes with the usual unicode marker for that.

Fixes #221

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
