### PR TITLE
fix(dispatcher): explicitly disable exception chaining

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -311,7 +311,7 @@ class Dispatcher:
         except KeyError:
             allowed = (repr(of.name) for of in OutputFormat)
             msg = f"Invalid value for --format; allowed are: {', '.join(sorted(allowed))}"
-            raise self._build_usage_exc(msg)  # noqa: TRY200 (Use `raise from`)
+            raise self._build_usage_exc(msg) from None
 
         if len(filtered_params) == 1:
             # at this point the remaining parameter should be a command
@@ -329,7 +329,7 @@ class Dispatcher:
             cmd_class = self.commands[cmdname]
         except KeyError:
             msg = f"command {cmdname!r} not found to provide help for"
-            raise self._build_usage_exc(msg)  # noqa: TRY200 (Use `raise from`)
+            raise self._build_usage_exc(msg) from None
 
         # instantiate the command and fill its arguments
         command = cmd_class(None)
@@ -402,7 +402,7 @@ class Dispatcher:
                         global_args[arg.name] = next(sysargs_it)
                     except StopIteration:
                         msg = f"The {arg.name!r} option expects one argument."
-                        raise self._build_usage_exc(msg)  # noqa: TRY200 (use 'raise from')
+                        raise self._build_usage_exc(msg) from None
             elif sysarg.startswith(tuple(options_with_equal)):
                 option, value = sysarg.split("=", 1)
                 arg = arg_per_option[option]
@@ -439,10 +439,10 @@ class Dispatcher:
             try:
                 verbosity_level = EmitterMode[global_args["verbosity"].upper()]
             except KeyError:
-                raise self._build_usage_exc(  # noqa: TRY200 (use 'raise from')
+                raise self._build_usage_exc(
                     "Bad verbosity level; valid values are "
                     "'quiet', 'brief', 'verbose', 'debug' and 'trace'."
-                )
+                ) from None
             emit.set_mode(verbosity_level)
         emit.trace(f"Raw pre-parsed sysargs: args={global_args} filtered={filtered_sysargs}")
 
@@ -474,7 +474,7 @@ class Dispatcher:
             self._command_class = self.commands[command]
         except KeyError:
             help_text = self._build_no_command_error(command)
-            raise ArgumentParsingError(help_text)  # noqa: TRY200 (use raise from)
+            raise ArgumentParsingError(help_text) from None
 
         emit.trace(f"General parsed sysargs: command={ command!r} args={cmd_args}")
         return global_args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
 lint = [
     "black==24.2.0",
     "codespell[toml]==2.2.6",
-    "ruff==0.1.15",
+    "ruff~=0.2.1",
     "yamllint==1.34.0"
 ]
 types = [
@@ -210,6 +210,7 @@ extend-select = [
     "ANN0",  # Type annotations for arguments other than `self` and `cls`
     "ANN2",  # Return type annotations
     "B026",  # Keyword arguments must come after starred arguments
+    "B904",  # re-raising an exception should include a `from`.
     # flake8-bandit: security testing. https://github.com/charliermarsh/ruff#flake8-bandit-s
     # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
     "S101", "S102",  # assert or exec


### PR DESCRIPTION
In these cases, the chaining doesn't provide useful additional data.

Drive-by: updates ruff to 0.2

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?
