### PR TITLE
feat: split the docs url into base and slug

### DIFF
--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -42,6 +42,10 @@ class CraftError(Exception):
     docs_url: Optional[str]
     """An URL to point the user to documentation (to be shown together with ``message``)."""
 
+    doc_slug: Optional[str]
+    """The slug to the user documentation. Needs a base url to form a full address.
+      Note that ``docs_url`` has preference if it is set."""
+
     logpath_report: bool
     """Whether the location of the log filepath should be presented in the screen as the
      final message."""
@@ -62,6 +66,7 @@ class CraftError(Exception):
         logpath_report: bool = True,
         reportable: bool = True,
         retcode: int = 1,
+        doc_slug: Optional[str] = None,
     ) -> None:
         super().__init__(message)
         self.details = details
@@ -70,6 +75,9 @@ class CraftError(Exception):
         self.logpath_report = logpath_report
         self.reportable = reportable
         self.retcode = retcode
+        self.doc_slug = doc_slug
+        if doc_slug and not doc_slug.startswith("/"):
+            self.doc_slug = "/" + doc_slug
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, CraftError):
@@ -82,6 +90,7 @@ class CraftError(Exception):
                     self.logpath_report == other.logpath_report,
                     self.reportable == other.reportable,
                     self.retcode == other.retcode,
+                    self.doc_slug == other.doc_slug,
                 ]
             )
         return NotImplemented

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -66,9 +66,9 @@ def get_initiated_emitter(tmp_path, monkeypatch):
     monkeypatch.setattr(messages, "_get_log_filepath", lambda appname: fake_logpath)
     with patch("craft_cli.messages.Printer", autospec=True) as mock_printer:
 
-        def func(mode, greeting="default greeting"):
+        def func(mode, *, greeting="default greeting", **kwargs):
             emitter = RecordingEmitter()
-            emitter.init(mode, "testappname", greeting)
+            emitter.init(mode, "testappname", greeting, **kwargs)
             emitter.printer_calls = mock_printer.mock_calls
             emitter.printer_calls.clear()
             return emitter
@@ -1062,5 +1062,49 @@ def test_reporterror_no_logpath(get_initiated_emitter):
 
     assert emitter.printer_calls == [
         call().show(sys.stderr, "test message", use_timestamp=True, end_line=True),
+        call().stop(),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("docs_base_url", "doc_slug"),
+    [
+        ("https://documentation.ubuntu.com/testcraft", "reference/error.html"),
+        ("https://documentation.ubuntu.com/testcraft/", "reference/error.html"),
+        ("https://documentation.ubuntu.com/testcraft", "/reference/error.html"),
+        ("https://documentation.ubuntu.com/testcraft/", "/reference/error.html"),
+    ],
+)
+def test_reporterror_doc_slug(get_initiated_emitter, docs_base_url, doc_slug):
+    emitter = get_initiated_emitter(EmitterMode.BRIEF, docs_base_url=docs_base_url)
+    error = CraftError("test message", logpath_report=False, doc_slug=doc_slug)
+    emitter.error(error)
+
+    full_docs_message = (
+        "For more information, check out: "
+        "https://documentation.ubuntu.com/testcraft/reference/error.html"
+    )
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "test message", use_timestamp=False, end_line=True),
+        call().show(sys.stderr, full_docs_message, use_timestamp=False, end_line=True),
+        call().stop(),
+    ]
+
+
+def test_reporterror_both_url_and_slug(get_initiated_emitter):
+    docs_base_url = "https://base-url.ubuntu.com/testcraft"
+    doc_slug = "/slug"
+    full_url = "https://full-url.ubuntu.com/testcraft/full"
+    emitter = get_initiated_emitter(EmitterMode.BRIEF, docs_base_url=docs_base_url)
+
+    # An error with both docs_url and doc_slug
+    error = CraftError("test message", logpath_report=False, docs_url=full_url, doc_slug=doc_slug)
+    emitter.error(error)
+
+    full_docs_message = f"For more information, check out: {full_url}"
+
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "test message", use_timestamp=False, end_line=True),
+        call().show(sys.stderr, full_docs_message, use_timestamp=False, end_line=True),
         call().stop(),
     ]


### PR DESCRIPTION
This commit provides a way to separate the base url for the project's docs and the slug for a specific topic. In particular, this is useful when raising a CraftError so that it holds just the slug of the user documentation for that issue, which is then combined by the Emitter into a full url when reporting the error to the user.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
