### PR TITLE
ci: add workflow to release to PyPI

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       # These tags should be protected, remember to enable the rule:
-      # https://github.com/canonical/starbase/settings/tag_protection
+      # https://github.com/canonical/craft-cli/settings/tag_protection
       - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,0 +1,60 @@
+name: Release
+on:
+  push:
+    tags:
+      # These tags should be protected, remember to enable the rule:
+      # https://github.com/canonical/starbase/settings/tag_protection
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  source-wheel:
+    runs-on: [self-hosted, jammy]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Fetch tag annotations
+        run: |
+          git fetch --force --tags --depth 1
+          git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          check-latest: true
+      - name: Build packages
+        run: |
+          pip install build twine
+          python3 -m build
+          twine check dist/*
+      - name: Upload pypi packages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-packages
+          path: dist/
+  pypi:
+    needs: ["source-wheel"]
+    runs-on: [self-hosted, jammy]
+    steps:
+      - name: Get packages
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-packages
+          path: dist/
+      - name: Publish to pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+  github-release:
+    needs: ["source-wheel"]
+    runs-on: [self-hosted, jammy]
+    steps:
+      - name: Get pypi artifacts
+        uses: actions/download-artifact@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            **


### PR DESCRIPTION
This workflow file is a copy of Starbase's, with the modification to run on self-hosted runners (and to use Python 3.10 instead of 3.11).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
