### PR TITLE
feat: add CraftCommandError

### DIFF
--- a/craft_cli/__init__.py
+++ b/craft_cli/__init__.py
@@ -31,13 +31,14 @@ except ImportError:  # pragma: no cover
 # is to break cyclic dependencies
 from .messages import EmitterMode, emit  # isort:skip
 from .dispatcher import BaseCommand, CommandGroup, Dispatcher, GlobalArgument
-from .errors import ArgumentParsingError, CraftError, ProvideHelpException
+from .errors import ArgumentParsingError, CraftError, CraftCommandError, ProvideHelpException
 from .helptexts import HIDDEN  # noqa: F401
 
 __all__ = [
     "ArgumentParsingError",
     "BaseCommand",
     "CommandGroup",
+    "CraftCommandError",
     "CraftError",
     "Dispatcher",
     "EmitterMode",

--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -211,7 +211,7 @@ class Dispatcher:
     :param default_command: the command to run if none was specified in the command line
     """
 
-    def __init__(  # noqa: PLR0913 (too many arguments)
+    def __init__(
         self,
         appname: str,
         commands_groups: list[CommandGroup],

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -304,7 +304,7 @@ class _PipeReaderThread(threading.Thread):
 class _StreamContextManager:
     """A context manager that provides a pipe for subprocess to write its output."""
 
-    def __init__(  # noqa: PLR0913 (too many arguments)
+    def __init__(
         self,
         printer: Printer,
         text: str | None,

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -45,14 +45,13 @@ try:
 except ImportError:
     _WINDOWS_MODE = False
 
+from craft_cli import errors
 from craft_cli.printer import Printer
 
 if TYPE_CHECKING:
     from types import TracebackType
 
     from typing_extensions import Self
-
-    from craft_cli import errors
 
 
 EmitterMode = enum.Enum("EmitterMode", "QUIET BRIEF VERBOSE DEBUG TRACE")
@@ -722,6 +721,12 @@ class Emitter:
 
         # the initial message
         self._printer.show(sys.stderr, str(error), use_timestamp=use_timestamp, end_line=True)
+
+        if isinstance(error, errors.CraftCommandError):
+            stderr = error.stderr
+            if stderr:
+                text = f"Captured error:\n{stderr}"
+                self._printer.show(sys.stderr, text, use_timestamp=use_timestamp, end_line=True)
 
         # detailed information and/or original exception
         if error.details:

--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -396,7 +396,7 @@ class Printer:
         if not avoid_logging:
             self._log(msg)
 
-    def progress_bar(  # noqa: PLR0913
+    def progress_bar(
         self,
         stream: TextIO | None,
         text: str,

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from craft_cli.errors import CraftError
+from craft_cli.errors import CraftError, CraftCommandError
 
 
 def test_crafterror_is_comparable():
@@ -78,3 +78,30 @@ def test_compare_crafterror_with_identical_attribute_values(argument_name):
     setattr(error2, argument_name, "foo")
 
     assert error1 == error2
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"), [(None, None), ("text", "text"), (b"text", "text")]
+)
+def test_command_error(stderr, expected):
+    err = CraftCommandError("message", stderr=stderr)
+    assert err.stderr == expected
+
+
+@pytest.mark.parametrize(
+    ("stderr1", "stderr2", "expected"),
+    [
+        (None, None, True),
+        ("text", "text", True),
+        (b"text", b"text", True),
+        (None, "text", False),
+        (None, b"text", False),
+        (b"text", "text", False),
+    ],
+)
+def test_compare_command_error(stderr1, stderr2, expected):
+    err1 = CraftCommandError("message", stderr=stderr1)
+    err2 = CraftCommandError("message", stderr=stderr2)
+
+    eq = err1 == err2
+    assert eq == expected


### PR DESCRIPTION
This new error class has a ``stderr`` attribute that holds the error output of an executed command. As the class' docstring indicates, this new attribute is halfway between ``brief`` and ``details``, verbosity-wise. It's meant to be used in cases where this error output is expected to be useful enough to the end user to make up for the extra text, even in "brief"-mode executions.

Fixes #260

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
