### PR TITLE
chore: show example of truncated git clone

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -517,7 +517,7 @@ def example_31():
     """Git clone subprocess output passing"""
     with emit.open_stream("Cloning:") as stream:
         subprocess.run(
-            ["git", "clone", "https://github.com/astral-sh/ruff/"],
+            ["git", "clone", "--progress", "https://github.com/astral-sh/ruff/"],
             stdout=stream,
             stderr=stream,
             check=True,

--- a/examples.py
+++ b/examples.py
@@ -513,6 +513,17 @@ def example_30():
         time.sleep(0.001)
 
 
+def example_31():
+    """Git clone subprocess output passing"""
+    with emit.open_stream("Cloning:") as stream:
+        subprocess.run(
+            ["git", "clone", "https://github.com/astral-sh/ruff/"],
+            stdout=stream,
+            stderr=stream,
+            check=True,
+        )
+
+
 # -- end of test cases
 
 if len(sys.argv) < 2:


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Regular `git clone` command returns few lines of output that indicate progress, if I use command directly:
```
Cloning into 'ruff'...
remote: Enumerating objects: 154777, done.
remote: Counting objects: 100% (10395/10395), done.
remote: Total 154777 (delta 9169), reused 9067 (delta 8428), pack-reused 144382
Receiving objects: 100% (154777/154777), 51.42 MiB | 21.99 MiB/s, done.
Resolving deltas: 100% (112591/112591), done.
```

In cli stream it's truncated to only:
```
:: Cloning into 'ruff'... - (2.0s)
```