### PR TITLE
fix: log arguments with debug

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -245,7 +245,7 @@ class Dispatcher:
         parser = _CustomArgumentParser(self._help_builder, prog=self._loaded_command.name)
         self._loaded_command.fill_parser(parser)
         self._parsed_command_args = parser.parse_args(self._command_args)
-        emit.trace(f"Command parsed sysargs: {self._parsed_command_args}")
+        emit.debug(f"Command parsed sysargs: {self._parsed_command_args}")
         return self._loaded_command
 
     def parsed_args(self) -> argparse.Namespace:
@@ -456,7 +456,7 @@ class Dispatcher:
             if self._default_command is None:
                 help_text = self._get_general_help(detailed=False)
                 raise ArgumentParsingError(help_text)
-            emit.trace(f"Using default command: {self._default_command.name!r}")
+            emit.debug(f"Using default command: {self._default_command.name!r}")
             # validated by BaseCommand
             assert self._default_command.name is not None  # noqa: S101 (use of assert)
             filtered_sysargs.insert(0, self._default_command.name)
@@ -476,7 +476,7 @@ class Dispatcher:
             help_text = self._build_no_command_error(command)
             raise ArgumentParsingError(help_text) from None
 
-        emit.trace(f"General parsed sysargs: command={ command!r} args={cmd_args}")
+        emit.debug(f"General parsed sysargs: command={ command!r} args={cmd_args}")
         return global_args
 
     def run(self) -> int | None:

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -97,11 +97,11 @@ def test_dispatcher_command_default_simple():
     groups = [CommandGroup("title", [cmd1, cmd2])]
     dispatcher = Dispatcher("appname", groups, default_command=cmd2)
 
-    with patch.object(emit, "trace") as mock_trace:
+    with patch.object(emit, "debug") as mock_debug:
         dispatcher.pre_parse_args([])
     assert dispatcher._command_class is cmd2
     assert dispatcher._command_args == []
-    mock_trace.assert_any_call("Using default command: 'somecommand2'")
+    mock_debug.assert_any_call("Using default command: 'somecommand2'")
 
 
 def test_dispatcher_command_default_with_options():


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

Parsed arguments can be helpful when debugging.