### PR TITLE
feat: support app_config in pre_parse_args()

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -281,7 +281,7 @@ class Dispatcher:
         return ArgumentParsingError(self._help_builder.get_usage_message(text))
 
     def _get_requested_help(  # noqa: PLR0912 (too many branches)
-        self, parameters: list[str]
+        self, parameters: list[str], app_config: Any
     ) -> str:
         """Produce the requested help depending on the rest of the command line params."""
         if len(parameters) == 0:
@@ -332,7 +332,7 @@ class Dispatcher:
             raise self._build_usage_exc(msg) from None
 
         # instantiate the command and fill its arguments
-        command = cmd_class(None)
+        command = cmd_class(app_config)
         parser = _CustomArgumentParser(self._help_builder, prog=command.name, add_help=False)
         command.fill_parser(parser)
 
@@ -413,7 +413,7 @@ class Dispatcher:
                 filtered_sysargs.append(sysarg)
         return global_args, filtered_sysargs
 
-    def pre_parse_args(self, sysargs: list[str]) -> dict[str, Any]:
+    def pre_parse_args(self, sysargs: list[str], app_config: Any = None) -> dict[str, Any]:
         """Pre-parse sys args.
 
         Several steps:
@@ -423,6 +423,8 @@ class Dispatcher:
         - validate global options and apply them
 
         - validate that command is correct (NOT loading and parsing its arguments)
+
+        If provided, ``app_config`` is passed to the command to be validated.
         """
         global_args, filtered_sysargs = self._parse_options(self.global_arguments, sysargs)
 
@@ -448,7 +450,7 @@ class Dispatcher:
 
         # handle requested help through -h/--help options
         if global_args["help"]:
-            help_text = self._get_requested_help(filtered_sysargs)
+            help_text = self._get_requested_help(filtered_sysargs, app_config)
             raise ProvideHelpException(help_text)
 
         if not filtered_sysargs or filtered_sysargs[0].startswith("-"):
@@ -466,7 +468,7 @@ class Dispatcher:
 
         # handle requested help through implicit "help" command
         if command == "help":
-            help_text = self._get_requested_help(cmd_args)
+            help_text = self._get_requested_help(cmd_args, app_config)
             raise ProvideHelpException(help_text)
 
         self._command_args = cmd_args

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.9.0 (2024-Oct-22)
+-------------------
+
+- The ``Dispatcher.pre_parse_args()`` method now accepts an ``app_config``
+  parameter, which is used to instantiate the command that will be validated.
+
 2.8.0 (2024-Oct-10)
 -------------------
 - Positional arguments are now displayed in 'help' outputs.

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -1480,7 +1480,14 @@ class AppConfigCommand(BaseCommand):
         )
 
 
-def test_helprequested_command_app_config():
+@pytest.mark.parametrize(
+    "sysargs",
+    [
+        "testapp app-config --help".split()[1:],
+        "testapp help app-config".split()[1:],
+    ],
+)
+def test_helprequested_command_app_config(sysargs):
     command_groups = [CommandGroup("group", [AppConfigCommand])]
     dispatcher = Dispatcher("testapp", command_groups)
 
@@ -1488,4 +1495,35 @@ def test_helprequested_command_app_config():
     expected_help = re.escape("number:  The number to use. Possible values are [1, 2, 3].")
 
     with pytest.raises(ProvideHelpException, match=expected_help):
-        dispatcher.pre_parse_args(["app-config", "--help"], app_config)
+        dispatcher.pre_parse_args(sysargs, app_config)
+
+
+class NoConfigCommand(BaseCommand):
+
+    name: str = "no-config"
+    help_msg: str = "Help text"
+    overview: str = "Overview"
+
+    def fill_parser(self, parser: ArgumentParser) -> None:
+        assert self.config is None
+
+        parser.add_argument(
+            "config",
+            help=f"Config was correctly None",
+        )
+
+
+@pytest.mark.parametrize(
+    "sysargs",
+    [
+        "testapp no-config --help".split()[1:],
+        "testapp help no-config".split()[1:],
+    ],
+)
+def test_helprequested_command_no_app_config(sysargs):
+    command_groups = [CommandGroup("group", [NoConfigCommand])]
+    dispatcher = Dispatcher("testapp", command_groups)
+
+    expected_help = "config:  Config was correctly None"
+    with pytest.raises(ProvideHelpException, match=expected_help):
+        dispatcher.pre_parse_args(sysargs)

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -14,12 +14,15 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
+import re
 import textwrap
+from argparse import ArgumentParser
+from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
 
-from craft_cli import dispatcher as dispatcher_mod
+from craft_cli import dispatcher as dispatcher_mod, BaseCommand
 from craft_cli.dispatcher import CommandGroup, Dispatcher, GlobalArgument
 from craft_cli.errors import ArgumentParsingError, ProvideHelpException
 from craft_cli.helptexts import HIDDEN, HelpBuilder, OutputFormat, process_overview_for_markdown
@@ -1285,7 +1288,7 @@ def test_helprequested_no_parameters():
     parameters = []
     dispatcher = Dispatcher("testapp", [])
     with patch("craft_cli.dispatcher.Dispatcher._get_general_help") as mock:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     mock.assert_called_once_with(detailed=False)
 
 
@@ -1294,7 +1297,7 @@ def test_helprequested_too_many_parameters():
     parameters = ["foo", "bar"]
     dispatcher = Dispatcher("testapp", [])
     with pytest.raises(ArgumentParsingError) as raised:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -1311,7 +1314,7 @@ def test_helprequested_detailed_ok():
     parameters = ["--all"]
     dispatcher = Dispatcher("testapp", [])
     with patch("craft_cli.dispatcher.Dispatcher._get_general_help") as mock:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     mock.assert_called_once_with(detailed=True)
 
 
@@ -1326,7 +1329,7 @@ def test_helprequested_detailed_extra(parameters):
     """Detailed help requested but with extra stuff."""
     dispatcher = Dispatcher("testapp", [])
     with pytest.raises(ArgumentParsingError) as raised:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -1347,7 +1350,7 @@ def test_helprequested_specific_command():
     parameters = ["somecmd"]
     with patch("craft_cli.helptexts.HelpBuilder.get_command_help") as mock:
         with patch("craft_cli.dispatcher.Dispatcher._get_global_options", return_value=[]):
-            dispatcher._get_requested_help(parameters)
+            dispatcher._get_requested_help(parameters, None)
     args = mock.call_args[0]
     assert isinstance(args[0], cmd)
     assert args[1] == []
@@ -1369,7 +1372,7 @@ def test_helprequested_format_noncommand(parameters):
     """Output format is not allowed for non-command help."""
     dispatcher = Dispatcher("testapp", [])
     with pytest.raises(ArgumentParsingError) as raised:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -1402,7 +1405,7 @@ def test_helprequested_command_format_ok(parameters, expected_format):
 
     with patch("craft_cli.helptexts.HelpBuilder.get_command_help") as mock:
         with patch("craft_cli.dispatcher.Dispatcher._get_global_options", return_value=[]):
-            dispatcher._get_requested_help(parameters)
+            dispatcher._get_requested_help(parameters, None)
     args = mock.call_args[0]
     assert isinstance(args[0], cmd)
     assert args[1] == []
@@ -1422,7 +1425,7 @@ def test_helprequested_command_format_bad(parameters):
     """Help for a command with a wrong format."""
     dispatcher = Dispatcher("testapp", [])
     with pytest.raises(ArgumentParsingError) as raised:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -1448,7 +1451,7 @@ def test_helprequested_command_format_truncated(parameters):
     """Help for a command with a format not really specified."""
     dispatcher = Dispatcher("testapp", [])
     with pytest.raises(ArgumentParsingError) as raised:
-        dispatcher._get_requested_help(parameters)
+        dispatcher._get_requested_help(parameters, None)
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -1458,3 +1461,31 @@ def test_helprequested_command_format_truncated(parameters):
     """
     )
     assert str(raised.value) == expected
+
+
+class AppConfigCommand(BaseCommand):
+
+    name: str = "app-config"
+    help_msg: str = "Help text"
+    overview: str = "Overview"
+
+    def fill_parser(self, parser: ArgumentParser) -> None:
+        assert isinstance(self.config, dict)
+
+        choices = self.config["choices"]
+        parser.add_argument(
+            "number",
+            choices=choices,
+            help=f"The number to use. Possible values are {choices}.",
+        )
+
+
+def test_helprequested_command_app_config():
+    command_groups = [CommandGroup("group", [AppConfigCommand])]
+    dispatcher = Dispatcher("testapp", command_groups)
+
+    app_config = {"choices": [1, 2, 3]}
+    expected_help = re.escape("number:  The number to use. Possible values are [1, 2, 3].")
+
+    with pytest.raises(ProvideHelpException, match=expected_help):
+        dispatcher.pre_parse_args(["app-config", "--help"], app_config)


### PR DESCRIPTION
This lets the commands of a given application access the configuration dict during fill_parser() even when building the help message, like in `app cmd -h`. Of course, this can only be used in cases where the configuration dict contains data that the application already has at pre_parse_args()-time.

Fixes #292

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
