### PR TITLE
chore(ci): generate notes when publishing a release

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch tag annotations
         run: |
+          # Note: we fetch the tags here instead of using actions/checkout's "fetch-tags"
+          # because of https://github.com/actions/checkout/issues/1467
           git fetch --force --tags --depth 1
           git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
       - name: Setup Python
@@ -53,8 +55,14 @@ jobs:
     steps:
       - name: Get pypi artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: pypi-packages
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          # Generate release notes on the new GH release
+          generate_release_notes: true
+          # Add wheel and source tarball
           files: |
-            **
+            *.whl
+            *.tar.gz


### PR DESCRIPTION
We can't enable Trusted Publishing yet because I need to be able to update the PyPI project first.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
