### PR TITLE
feat(emitter): decouple message emitter and printer

### DIFF
--- a/craft_cli/errors.py
+++ b/craft_cli/errors.py
@@ -23,8 +23,8 @@ __all__ = [
 from typing import Any, Optional, Union, cast
 
 
-class CraftError(Exception):
-    """Signal a program error with a lot of information to report."""
+class BaseErrorData:
+    """Common error fields for CraftError and CLI protocol."""
 
     message: str
     """The main message to the user, to be shown as first line (and probably only that,
@@ -55,6 +55,10 @@ class CraftError(Exception):
 
     retcode: int
     """The code to return when the application finishes."""
+
+
+class CraftError(BaseErrorData, Exception):
+    """Signal a program error with a lot of information to report."""
 
     def __init__(  # noqa: PLR0913 (too many arguments)
         self,

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -80,6 +80,7 @@ _MSG_PROGRESS = "<p>"
 _MSG_ERROR = "<E>"
 _MSG_STREAM = "<S>"
 
+
 class _ErrorMessage(BaseErrorData):
     message: str
     is_command_error: bool
@@ -120,17 +121,17 @@ class _ErrorMessage(BaseErrorData):
         :return: The error message for the CLI protocol.
         """
         msg = cls(
-            message = str(error),
-            details = error.details,
-            resolution = error.resolution,
-            docs_url = error.docs_url,
-            doc_slug = error.doc_slug,
-            stderr = "",
-            logpath_report = error.logpath_report,
-            reportable = error.reportable,
-            retcode = error.retcode,
-            is_command_error = False,
-            traceback_lines = [],
+            message=str(error),
+            details=error.details,
+            resolution=error.resolution,
+            docs_url=error.docs_url,
+            doc_slug=error.doc_slug,
+            stderr="",
+            logpath_report=error.logpath_report,
+            reportable=error.reportable,
+            retcode=error.retcode,
+            is_command_error=False,
+            traceback_lines=[],
         )
 
         if error.__cause__:
@@ -667,7 +668,9 @@ class Emitter:
         """
         self._handle_cli_message(_MSG_TRACE, text)
 
-    def _handle_cli_message(self, msg_type: str, text: str) -> None:  # noqa: PLR0912 (too many branches)
+    def _handle_cli_message(
+        self, msg_type: str, text: str
+    ) -> None:  # noqa: PLR0912 (too many branches)
         """Process emitted message according to the local system configuration.
 
         Emitted messages can be handled differently according to the type of the
@@ -688,13 +691,19 @@ class Emitter:
                 self._printer.show(None, text, use_timestamp=False, ephemeral=True, end_line=False)
             elif self._mode == EmitterMode.BRIEF:
                 # third party stream to stderr
-                self._printer.show(sys.stderr, text, use_timestamp=False, ephemeral=True, end_line=False)
+                self._printer.show(
+                    sys.stderr, text, use_timestamp=False, ephemeral=True, end_line=False
+                )
             elif self._mode == EmitterMode.VERBOSE:
                 # third party stream to stderr
-                self._printer.show(sys.stderr, text, use_timestamp=False, ephemeral=False, end_line=True)
+                self._printer.show(
+                    sys.stderr, text, use_timestamp=False, ephemeral=False, end_line=True
+                )
             else:
                 # third party stream to stderr with timestamp
-                self._printer.show(sys.stderr, text, use_timestamp=True, ephemeral=False, end_line=True)
+                self._printer.show(
+                    sys.stderr, text, use_timestamp=True, ephemeral=False, end_line=True
+                )
 
         elif msg_type == _MSG_MESSAGE:
             stream = None if self._mode == EmitterMode.QUIET else sys.stdout
@@ -754,7 +763,6 @@ class Emitter:
         else:
             raise RuntimeError("unknown message type '{msg_type}'")
 
-
     def _get_progress_params(
         self, permanent: bool  # noqa: FBT001 (boolean positional arg)
     ) -> tuple[TextIO | None, bool, bool]:
@@ -797,7 +805,6 @@ class Emitter:
             self._handle_cli_message(_MSG_PROGRESS_PERMANENT, text)
         else:
             self._handle_cli_message(_MSG_PROGRESS, text)
-
 
     @_active_guard()
     def progress_bar(
@@ -925,7 +932,6 @@ class Emitter:
         msg = _ErrorMessage.from_error(error)
         self._handle_cli_message(_MSG_ERROR, msg.dumps())
         self._stop()
-
 
     @_active_guard()
     def set_secrets(self, secrets: list[str]) -> None:

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -339,9 +339,9 @@ class _PipeReaderThread(threading.Thread):
             unicode_line = unicode_line.replace("\t", "  ")
             text = f":: {unicode_line}"
 
-            self._handle_cli_message(_MSG_STREAM, text)
+            self.handle_message(_MSG_STREAM, text)
 
-    def _handle_cli_message(self, _msg_type: str, text: str) -> None:
+    def handle_message(self, _msg_type: str, text: str) -> None:
         """Process emitted message according to the local system configuration."""
         self.printer.show(self.stream, text, **self.printer_flags)
 
@@ -627,7 +627,7 @@ class Emitter:
     @_active_guard()
     def stream(self, text: str) -> None:
         """Show strings streamed from a stream context."""
-        self._handle_cli_message(_MSG_STREAM, text)
+        self.handle_message(_MSG_STREAM, text)
 
     @_active_guard()
     def message(self, text: str) -> None:
@@ -635,7 +635,7 @@ class Emitter:
 
         Normally used as the final message, to show the result of a command.
         """
-        self._handle_cli_message(_MSG_MESSAGE, text)
+        self.handle_message(_MSG_MESSAGE, text)
 
     @_active_guard()
     def verbose(self, text: str) -> None:
@@ -644,7 +644,7 @@ class Emitter:
         Useful to provide more information to the user that shouldn't be exposed
         when in brief mode for clarity and simplicity.
         """
-        self._handle_cli_message(_MSG_VERBOSE, text)
+        self.handle_message(_MSG_VERBOSE, text)
 
     @_active_guard()
     def debug(self, text: str) -> None:
@@ -654,7 +654,7 @@ class Emitter:
         for the app developers to understand why things are failing or performing
         forensics on the produced logs.
         """
-        self._handle_cli_message(_MSG_DEBUG, text)
+        self.handle_message(_MSG_DEBUG, text)
 
     @_active_guard()
     def trace(self, text: str) -> None:
@@ -666,11 +666,11 @@ class Emitter:
 
         It only produces information to the screen and into the logs if in TRACE mode.
         """
-        self._handle_cli_message(_MSG_TRACE, text)
+        self.handle_message(_MSG_TRACE, text)
 
-    def _handle_cli_message(
+    def handle_message(  # noqa: PLR0912 (too many branches)
         self, msg_type: str, text: str
-    ) -> None:  # noqa: PLR0912 (too many branches)
+    ) -> None:
         """Process emitted message according to the local system configuration.
 
         Emitted messages can be handled differently according to the type of the
@@ -802,9 +802,9 @@ class Emitter:
         line (unless verbose/trace mode).
         """
         if permanent:
-            self._handle_cli_message(_MSG_PROGRESS_PERMANENT, text)
+            self.handle_message(_MSG_PROGRESS_PERMANENT, text)
         else:
-            self._handle_cli_message(_MSG_PROGRESS, text)
+            self.handle_message(_MSG_PROGRESS, text)
 
     @_active_guard()
     def progress_bar(
@@ -930,7 +930,7 @@ class Emitter:
     def error(self, error: errors.CraftError) -> None:
         """Handle the system's indicated error and stop machinery."""
         msg = _ErrorMessage.from_error(error)
-        self._handle_cli_message(_MSG_ERROR, msg.dumps())
+        self.handle_message(_MSG_ERROR, msg.dumps())
         self._stop()
 
     @_active_guard()


### PR DESCRIPTION
Introduce a common protocol that sits between message emitters and the
screen printer and log handler, as the first step to allow the local
system to listen for remotely emitted messages. This is intended to be
used for emitter message streaming from managed instances.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
