### PR TITLE
fix: only greet once when setting the same mode

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -510,6 +510,9 @@ class Emitter:
     @_active_guard()
     def set_mode(self, mode: EmitterMode) -> None:
         """Set the mode of the emitter."""
+        if mode == self._mode:
+            return
+
         self._mode = mode
         self._log_handler.mode = mode
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.10.1 (2024-Nov-11)
+--------------------
+
+- Fix an issue where setting an ``Emitter`` to the same mode multiple times
+  resulted in multiple greetings.
+
 2.10.0 (2024-Oct-31)
 --------------------
 - Support adding a link to documentation in help messages.


### PR DESCRIPTION
With this fix, ``Emitter.set_mode(mode)`` becomes a no-op if the emitter is already at that ``mode``. This scenario can happen, for example, if the Emitter is initialized with a mode and then the Dispatcher sets the same mode during command-line handling.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
