### PR TITLE
Remove black

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -346,7 +346,9 @@ class _Handler(logging.Handler):
     """A logging handler that emits messages through the core Printer."""
 
     def __init__(
-        self, printer: Printer, streaming_brief: bool = False  # noqa: FBT001, FBT002
+        self,
+        printer: Printer,
+        streaming_brief: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
         """Init the handler.
 
@@ -592,7 +594,8 @@ class Emitter:
             self._printer.show(sys.stderr, text, use_timestamp=True)
 
     def _get_progress_params(
-        self, permanent: bool  # noqa: FBT001 (boolean positional arg)
+        self,
+        permanent: bool,  # noqa: FBT001 (boolean positional arg)
     ) -> tuple[TextIO | None, bool, bool]:
         """Calculate the different parameters for progress information."""
         if self._mode == EmitterMode.QUIET:
@@ -643,7 +646,10 @@ class Emitter:
 
     @_active_guard()
     def progress_bar(
-        self, text: str, total: float, delta: bool = True  # noqa: FBT001, FBT002
+        self,
+        text: str,
+        total: float,
+        delta: bool = True,  # noqa: FBT001, FBT002
     ) -> _Progresser:
         """Progress information for a potentially long-running single step of a command.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dev = [
     "pytest-subprocess"
 ]
 lint = [
-    "black==24.10.0",
     "codespell[toml]==2.3.0",
     "yamllint==1.35.1"
 ]
@@ -88,11 +87,6 @@ exclude = [
     "results*",
     "tests*",
 ]
-
-[tool.black]
-target-version = ["py38"]
-line-length = 99
-extend-exclude = "docs/conf.py"
 
 [tool.codespell]
 ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented"
@@ -248,9 +242,9 @@ lint.ignore = [
     "TRY003",  # Avoid specifying long messages outside the exception class
 
     "PT001",  # Add parentheses to parameter-less pytest.fixture
-    "PT004",  # Fixture {function} does not return anything, add leading underscore
 
     "ANN401", # Disallow Any in parameters (reason: too restrictive)
+    "ISC001", # Avoid potential issues with formatting
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
-    lint-{black,ruff,pyright,shellcheck,codespell,docs}
+    lint-{ruff,pyright,shellcheck,codespell,docs}
     test-{py38,py310,py311}
 minversion = 4.5
 # Tox will use these requirements to bootstrap a venv if necessary.
@@ -69,15 +69,15 @@ allowlist_externals =
 find = git ls-files
 filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
 
-[testenv:lint-{black,ruff,shellcheck,codespell,yaml}]
+[testenv:lint-{ruff,shellcheck,codespell,yaml}]
 description = Lint the source code
 base = testenv, lint
 labels = lint
 commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
-    black: black --check --diff {tty:--color} {posargs} .
     ruff: ruff check --respect-gitignore {posargs} .
+    ruff: ruff format --diff {posargs:.}
     shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
     codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
     yaml: yamllint {posargs} .
@@ -96,13 +96,14 @@ commands =
     pyright: pyright {posargs}
     mypy: mypy --install-types --non-interactive {posargs:.}
 
-[testenv:format-{black,ruff,codespell}]
+[testenv:format-{ruff,codespell}]
 description = Automatically format source code
 base = testenv, lint
 labels = format
 commands =
     black: black {tty:--color} {posargs} .
     ruff: ruff check --fix --respect-gitignore {posargs} .
+    ruff: ruff format {posargs: .}
     codespell: codespell --toml {tox_root}/pyproject.toml --write-changes {posargs}
 
 [docs]  # Sphinx documentation configuration


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

The version of black was not supported with Python 3.8, the alternative was to switch to the snap version of black.

The commit affecting pyproject.toml and tox.ini is transposed from https://github.com/canonical/charmcraft/commit/d2b40dfbece3e9cc8577c19407c2dedbc30e9d2f and https://github.com/canonical/charmcraft/commit/9583793226b73478b9af24d649f0c1ca2b83c9bb with the exception of the ISC ignore in pyproject.toml

The second commit is a result of the ruff formatting