### PR TITLE
feat: confirm method for the emitter

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -780,6 +780,29 @@ class Emitter:
     def set_secrets(self, secrets: list[str]) -> None:
         """Set the list of strings that should be masked out in all output."""
         self._printer.set_secrets(secrets)
+
+    @_active_guard()
+    def confirm(self, prompt: str, *, default: bool = False) -> bool:
+        """Query user for yes/no answer.
+
+        If stdin is not a tty, the default value is returned.
+        If user returns an empty answer, the default value is returned.
+        :returns: True if answer starts with [yY], False if answer starts with [nN],
+            otherwise the default.
+        """
+        if not sys.stdin.isatty():
+            return default
+
+        choices = " [Y/n]: " if default else " [y/N]: "
+
+        with self.pause():
+            reply = input(prompt + choices).lower().strip()
+
+        if reply and reply[0] == "y":
+            return True
+        if reply and reply[0] == "n":
+            return False
+        return default
 
 
 # module-level instantiated Emitter; this is the instance all code shall use and Emitter

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.12.0 (2024-Dec-XX)
+--------------------
+
+- Add a ``confirm`` method to the emitter for asking a yes-no question.
+
 2.11.0 (2024-Dec-12)
 --------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@
 
 import pytest
 
+from craft_cli.messages import EmitterMode
 from craft_cli.printer import Printer, _Spinner
 
 
@@ -79,3 +80,8 @@ def recording_printer(tmp_path):
     yield recording_printer
     if not recording_printer.stopped:
         recording_printer.stop()
+
+
+@pytest.fixture(params=EmitterMode)
+def emitter_mode(request) -> EmitterMode:
+    return request.param

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -1220,6 +1220,8 @@ def test_confirm_with_user_defaults_without_tty(get_initiated_emitter, emitter_m
         ("N", False),
         ("no", False),
         ("NO", False),
+        (" Yes sir Mr. Callahan Sir!", True),
+        (" nah yeah? Yeah nah!    ", False)
     ],
 )
 @pytest.mark.usefixtures("mock_isatty")


### PR DESCRIPTION
This adds a confirm method to the emitter, allowing the program to ask the user a yes/no question.

Fixes #130 

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
