### PR TITLE
fix(pytest): revert "add an assert_error plugin method"

### DIFF
--- a/craft_cli/pytest_plugin.py
+++ b/craft_cli/pytest_plugin.py
@@ -22,12 +22,12 @@ import os
 import pathlib
 import re
 import tempfile
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from unittest.mock import call
 
 import pytest
 
-from craft_cli import errors, messages, printer
+from craft_cli import messages, printer
 
 if TYPE_CHECKING:
     from unittest.mock import _Call
@@ -163,18 +163,6 @@ class RecordingEmitter:
         """
         self.assert_interactions([call("message", text) for text in texts])
 
-    def assert_error(self, error: errors.CraftError) -> errors.CraftError:
-        """Check that the 'error' method was called with the given error."""
-        # Error should be the last thing called, so start at the end.
-        errors_called = []
-        for stored_call in reversed(self.interactions):
-            if stored_call.args[0] != "error":
-                continue
-            errors_called.append(stored_call.args[1])
-            if stored_call.args[1] == error:
-                return cast(errors.CraftError, stored_call.args[1])
-        raise AssertionError(f"Error not emitted: {error!r}", errors_called[::-1])
-
     def assert_interactions(self, expected_call_list):
         """Check that the expected call list happen at some point between all stored calls.
 
@@ -217,7 +205,7 @@ class _RecordingProgresser:
 def emitter(monkeypatch):
     """Provide a helper to test everything that was shown using the Emitter."""
     recording_emitter = RecordingEmitter()
-    for method_name in ("message", "progress", "verbose", "debug", "trace", "error"):
+    for method_name in ("message", "progress", "verbose", "debug", "trace"):
         monkeypatch.setattr(
             messages.emit,
             method_name,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,8 @@ included in each version.
 2.12.0 (2024-Dec-XX)
 --------------------
 
-- Remove the ``assert_error`` plugin method.
+- Remove the ``assert_error`` pytest plugin method. For checking errors, we
+  recommend using ``capsys`` instead.
 - Add a ``confirm`` method to the emitter for asking a yes-no question.
 
 2.11.0 (2024-Dec-12)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.12.0 (2024-Dec-XX)
+--------------------
+
+- Remove the ``assert_error`` plugin method.
+
 2.11.0 (2024-Dec-12)
 --------------------
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,13 +14,12 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """Test the fixtures provided by Craft CLI."""
-import copy
+
 from unittest.mock import call
 
 import pytest
 
-from craft_cli import messages, printer, errors
-
+from craft_cli import messages, printer
 
 # -- tests for the `init_emitter` auto-fixture
 
@@ -182,41 +181,6 @@ def test_emitter_messages(emitter):
             "Got: 2",
         ]
     )
-
-
-@pytest.mark.parametrize(
-    "error",
-    [
-        errors.CraftError("Basic error"),
-        errors.CraftError("Detailed", details="Very detailed"),
-        errors.CraftError("Resolved", resolution="640x480"),
-        errors.CraftError("Documented", docs_url="https://docs.ubuntu.com"),
-        errors.CraftError("Detailed Resolved", details="Extra fine", resolution="3840x2160"),
-    ],
-)
-def test_emitter_error_success(emitter, error):
-    """Verify that the checking the emitter for the correct error succeeds."""
-    error_copy = copy.deepcopy(error)  # Ensure we're not just checking identity.
-    messages.emit.error(error)
-    assert emitter.assert_error(error_copy) is error
-
-
-@pytest.mark.parametrize(
-    ("error", "assert_error"),
-    [
-        (errors.CraftError("Basic"), errors.CraftError("Very basic")),
-        (
-            errors.CraftError("Detailed", details="Case sensitive"),
-            errors.CraftError("Detailed", details="case Sensitive"),
-        ),
-    ],
-)
-def test_emitter_error_failure(emitter, error, assert_error):
-    """Verify that checking the emitter for the wrong error fails."""
-    messages.emit.error(error)
-    with pytest.raises(AssertionError, match="Error not emitted:") as exc_info:
-        emitter.assert_error(assert_error)
-    assert exc_info.value.args[1] == [error]
 
 
 def test_emitter_interactions_positive_complete(emitter):


### PR DESCRIPTION
Reverts canonical/craft-cli#218

Breaks #162 

Confirmed this is the cause. Compare:

- With #218: https://github.com/canonical/craft-application/actions/runs/12305359436/job/34344765176?pr=586
- Without: https://github.com/canonical/craft-application/actions/runs/12305776816/job/34346114053?pr=594