### PR TITLE
docs: finalize 2.13.0 changelog

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -38,7 +38,7 @@ jobs:
           path: dist/
   pypi:
     needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted, jammy, amd64]
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-2.13.0 (2024-Dec-XX)
+2.13.0 (2024-Dec-16)
 --------------------
 
 - Show error details in every mode except quiet.


### PR DESCRIPTION
Also manually-cherry-pick a starbase commit to constrain wheel uploads to `amd64` 