### PR TITLE
feat: add prompt to emitter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,15 @@ repos:
       - id: check-toml
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # renovate: datasource=pypi;depName=ruff
-    rev: "v0.0.269"
+    rev: "v0.8.3"
     hooks:
+      # Run the linter
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/psf/black
-    # renovate: datasource=pypi;depName=black
-    rev: "23.3.0"
-    hooks:
-      - id: black
+      # Run the formatter
+      - id: ruff-format
   - repo: https://github.com/adrienverge/yamllint.git
     # renovate: datasource=pypi;depName=yamllint
     rev: "v1.32.0"

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -816,7 +816,7 @@ class Emitter:
         :param prompt_text: text displayed to user while asking for an input.
         :param hide: hide user input if True.
         :returns: value that was provided by user.
-        :raises: CraftError if shell is not interactive or input is empty
+        :raises: CraftError if shell is not interactive or input is empty.
         """
         if not sys.stdin.isatty():
             raise errors.CraftError("prompting not possible without tty")

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -25,6 +25,7 @@ __all__ = [
 
 import enum
 import functools
+import getpass
 import logging
 import os
 import pathlib
@@ -805,6 +806,27 @@ class Emitter:
         if reply and reply[0] == "n":
             return False
         return default
+
+    @_active_guard()
+    def prompt(self, prompt: str, *, hide: bool = False) -> str:
+        """Prompt user for input.
+
+        If stdin is not a tty a CraftError is raised.
+
+        :param hide: hide user input if True.
+        :returns: value that was provided by user.
+        :raises: CraftError if shell is not interactive or input is empty
+        """
+        if not sys.stdin.isatty():
+            raise errors.CraftError("prompting not possible without tty")
+
+        method: Callable[[str], str] = getpass.getpass if hide else input  # type: ignore[assignment]
+
+        with self.pause():
+            val = method(prompt).strip()
+        if not val:
+            raise errors.CraftError("input cannot be empty")
+        return val
 
 
 # module-level instantiated Emitter; this is the instance all code shall use and Emitter

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -808,11 +808,12 @@ class Emitter:
         return default
 
     @_active_guard()
-    def prompt(self, prompt: str, *, hide: bool = False) -> str:
+    def prompt(self, prompt_text: str, *, hide: bool = False) -> str:
         """Prompt user for input.
 
         If stdin is not a tty a CraftError is raised.
 
+        :param prompt_text: text displayed to user while asking for an input.
         :param hide: hide user input if True.
         :returns: value that was provided by user.
         :raises: CraftError if shell is not interactive or input is empty
@@ -823,7 +824,7 @@ class Emitter:
         method: Callable[[str], str] = getpass.getpass if hide else input  # type: ignore[assignment]
 
         with self.pause():
-            val = method(prompt).strip()
+            val = method(prompt_text).strip()
         if not val:
             raise errors.CraftError("input cannot be empty")
         return val

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.14.0 (2025-Jan-DD)
+--------------------
+
+- Add a ``prompt`` method to the emitter to ask for user input.
+
 2.13.0 (2024-Dec-16)
 --------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ included in each version.
 2.14.0 (2025-Jan-DD)
 --------------------
 
-- Add a ``prompt`` method to the emitter to ask for user input.
+- Add a ``prompt`` method to the emitter for asking user for an input.
 
 2.13.0 (2024-Dec-16)
 --------------------


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Add a functionality to prompt user for an input.
Additionally with `hide` set to `True` user may be asked for a secret input.

(CRAFT-3739)