### PR TITLE
ci(test): run on 3.12 instead of 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,10 +52,8 @@ jobs:
         with:
           python-version: |
             3.8
-            3.9
             3.10
-            3.11
-            3.12-dev
+            3.12
       - name: Configure environment
         run: |
           echo "::group::pip install"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
     lint-{ruff,pyright,shellcheck,codespell,docs}
-    test-{py38,py310,py311}
+    test-{py38,py310,py312}
 minversion = 4.5
 # Tox will use these requirements to bootstrap a venv if necessary.
 # tox-igore-env-name-mismatch allows us to have one virtualenv for all linting.
@@ -36,7 +36,7 @@ commands_pre = mkdir -p results
 base = testenv, test
 description = Run unit tests with pytest
 labels =
-    py38, py310, py311: tests, unit-tests
+    py38, py310, py312: tests, unit-tests
 commands =
     # NOTE: we use `coverage` directly here instead of pytest-cov because the loading of the
     # pytest plugin provided by craft-cli means that some code gets imported *before*
@@ -48,7 +48,7 @@ commands =
 base = testenv, test
 description = Run integration tests with pytest
 labels =
-    py38, py310, py311: tests, integration-tests
+    py38, py310, py312: tests, integration-tests
 commands =
     # NOTE: we use `coverage` directly here instead of pytest-cov because the loading of the
     # pytest plugin provided by craft-cli means that some code gets imported *before*


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Run tests in CI on Python `3.12` instead of `3.11`