### PR TITLE
chore: update ruff configuration for 0.8

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -483,7 +483,7 @@ class Dispatcher:
             help_text = self._build_no_command_error(command)
             raise ArgumentParsingError(help_text) from None
 
-        emit.trace(f"General parsed sysargs: command={ command!r} args={cmd_args}")
+        emit.trace(f"General parsed sysargs: command={command!r} args={cmd_args}")
         return global_args
 
     def run(self) -> int | None:

--- a/craft_cli/helptexts.py
+++ b/craft_cli/helptexts.py
@@ -227,8 +227,7 @@ class HelpBuilder:
         # append documentation links to block for more help
         if self._docs_base_url:
             more_help_text += (
-                f"\nFor more information about {self.appname}, "
-                f"check out: {self._docs_base_url}"
+                f"\nFor more information about {self.appname}, check out: {self._docs_base_url}"
             )
         textblocks.append(more_help_text)
 
@@ -282,14 +281,11 @@ class HelpBuilder:
             textblocks.append("\n".join(group_lines))
 
         more_help_text = (
-            f"For more information about a specific command, run '{self.appname} "
-            "help <command>'."
-            ""
+            f"For more information about a specific command, run '{self.appname} help <command>'."
         )
         if self._docs_base_url:
             more_help_text += (
-                f"\nFor more information about {self.appname}, "
-                f"check out: {self._docs_base_url}"
+                f"\nFor more information about {self.appname}, check out: {self._docs_base_url}"
             )
         textblocks.append(more_help_text)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ lint.select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
-    "TCH",  # Guard imports only used for type checking behind a type-checkning block.
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code
@@ -228,7 +227,6 @@ lint.extend-select = [
     "RUF100",  # #noqa directive that doesn't flag anything
 ]
 lint.ignore = [
-    "ANN10",  # Type annotations for `self` and `cls`
     #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
     "E501",  # Line too long (reason: black will automatically fix this for us)
     "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ lint.select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
+    "TC",   # Guard imports only used for type checking behind a type-checking block.
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code


### PR DESCRIPTION
Two of the referenced linter rules in pyproject were unsupported by the schema. This PR removes them.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?