### PR TITLE
feat(emitter): add a log dumping function

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -781,17 +781,16 @@ class Emitter:
         self._stop()
 
     @_active_guard()
-    def dump_log_contents(self, log_path: pathlib.Path | str, prefix: str = "::") -> None:
-        """Dump the contents of an external log file into the emitter log."""
-        # Open a path object in case we received a string
-        if isinstance(log_path, str):
-            log_path = pathlib.Path(log_path)
+    def append_to_log(self, file: TextIO, prefix: str = ":: ") -> None:
+        """Dump the contents of an external log file into the emitter log.
 
-        with log_path.open() as log_file:
-            for line in log_file:
-                text = f"{prefix} {line}"
-                # Don't set the stream so it only goes to the log file
-                self._printer.show(None, text, use_timestamp=False)
+        :param file: A file I/O object to read from
+        :param prefix: A prefix for every line printed. Defaults to ":: ".
+        """
+        for line in file.readlines():
+            text = f"{prefix}{line}"
+            # Don't set the stream so it only goes to the log file
+            self._printer.show(None, text, use_timestamp=False)
 
     @_active_guard()
     def set_secrets(self, secrets: list[str]) -> None:

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -782,7 +782,7 @@ class Emitter:
 
     @_active_guard()
     def dump_log_contents(self, log_path: pathlib.Path | str, prefix: str = "::") -> None:
-        """Dump the contents of a log file."""
+        """Dump the contents of an external log file into the emitter log."""
         # Open a path object in case we received a string
         if isinstance(log_path, str):
             log_path = pathlib.Path(log_path)

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -780,7 +780,7 @@ class Emitter:
         self._report_error(error)
         self._stop()
 
-    @_active_guard(ignore_when_stopped=True)
+    @_active_guard()
     def dump_log_contents(self, log_path: pathlib.Path | str, prefix: str = "::") -> None:
         """Dump the contents of a log file."""
         # Open a path object in case we received a string

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -780,6 +780,23 @@ class Emitter:
         self._report_error(error)
         self._stop()
 
+    @_active_guard(ignore_when_stopped=True)
+    def dump_log_contents(self, log_path: pathlib.Path | str, prefix: str = "::") -> None:
+        """Dump the contents of a log file."""
+        # Open a path object in case we received a string
+        log_path = pathlib.Path(log_path)
+
+        # Same settings as debug
+        if self._mode in (EmitterMode.QUIET, EmitterMode.BRIEF, EmitterMode.VERBOSE):
+            stream = None
+        else:
+            stream = sys.stderr
+
+        with log_path.open() as log_file:
+            for line in log_file:
+                text = f"{prefix} {line}"
+                self._printer.show(stream, text, use_timestamp=False)
+
     @_active_guard()
     def set_secrets(self, secrets: list[str]) -> None:
         """Set the list of strings that should be masked out in all output."""

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -789,8 +789,8 @@ class Emitter:
         """
         for line in file:
             text = f"{prefix}{line}"
-            # Don't set the stream so it only goes to the log file
-            self._printer.show(None, text, use_timestamp=False)
+            self._printer.log.write(text)
+        self._printer.log.flush()
 
     @_active_guard()
     def set_secrets(self, secrets: list[str]) -> None:

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -787,7 +787,7 @@ class Emitter:
         :param file: A file I/O object to read from
         :param prefix: A prefix for every line printed. Defaults to ":: ".
         """
-        for line in file.readlines():
+        for line in file:
             text = f"{prefix}{line}"
             # Don't set the stream so it only goes to the log file
             self._printer.show(None, text, use_timestamp=False)

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -843,6 +843,11 @@ class Emitter:
             raise errors.CraftError("input cannot be empty")
         return val
 
+    @property
+    def log_filepath(self) -> pathlib.Path:
+        """The path to the log file."""
+        return self._log_filepath
+
 
 # module-level instantiated Emitter; this is the instance all code shall use and Emitter
 # shall not be instantiated again for the process' run

--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -784,18 +784,14 @@ class Emitter:
     def dump_log_contents(self, log_path: pathlib.Path | str, prefix: str = "::") -> None:
         """Dump the contents of a log file."""
         # Open a path object in case we received a string
-        log_path = pathlib.Path(log_path)
-
-        # Same settings as debug
-        if self._mode in (EmitterMode.QUIET, EmitterMode.BRIEF, EmitterMode.VERBOSE):
-            stream = None
-        else:
-            stream = sys.stderr
+        if isinstance(log_path, str):
+            log_path = pathlib.Path(log_path)
 
         with log_path.open() as log_file:
             for line in log_file:
                 text = f"{prefix} {line}"
-                self._printer.show(stream, text, use_timestamp=False)
+                # Don't set the stream so it only goes to the log file
+                self._printer.show(None, text, use_timestamp=False)
 
     @_active_guard()
     def set_secrets(self, secrets: list[str]) -> None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,7 @@ Breaking changes
 
 New features
 
-    - Add a ``dump_log_contents`` method to the emitter, which reads from a file
+    - Add an ``append_to_log`` method to the emitter, which reads from a file
       and dumps it directly into the log.
     - Add a ``log_filepath`` read-only property to the emitter.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,12 @@ Breaking changes
     - Deprecates support for Python 3.8 and adds support for Python 3.11
       and 3.12.
 
+New features
+
+    - Add a ``dump_log_contents`` method to the emitter, which reads from a file
+      and dumps it directly into the log.
+    - Add a ``log_filepath`` read-only property to the emitter.
+
 2.15.0 (2025-Jan-23)
 --------------------
 

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -18,12 +18,10 @@
 
 import logging
 import sys
-from types import MethodType
 from unittest import mock
 from unittest.mock import call, patch
 from typing import Any, cast, Callable
 
-import craft_cli
 import pytest
 import pytest_mock
 
@@ -91,6 +89,10 @@ def get_initiated_emitter(tmp_path, monkeypatch):
 
 @pytest.fixture
 def emitter_methods() -> Callable[[Emitter | RecordingEmitter, list[str]], list[Callable[..., Any]]]:
+    """Provide a list of all public methods on an Emitter object.
+
+    Optionally filter out any methods that aren't wanted for testing.
+    """
     def _inner(emitter, exclude: list[str] = []) -> list[Callable[..., Any]]:
         # Collect all the public methods in Emitter
         all_methods = [item for item in dir(Emitter) if item[0] != "_"]
@@ -119,7 +121,6 @@ def emitter_methods() -> Callable[[Emitter | RecordingEmitter, list[str]], list[
     ],
 )
 def test_init_quietish(mode, tmp_path, monkeypatch):
-
     """Init the class in some quiet-ish mode."""
     # avoid using a real log file
     fake_logpath = str(tmp_path / FAKE_LOG_NAME)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

Adds a new function to dump external logs directly into the emitter's log file, bypassing printing to the terminal and giving better customization for log behavior in the future.

It additionally adds a public `log_filepath` read-only property so consumers of the emitter can more easily access and test the contents of the log.

Required by https://github.com/canonical/craft-application/pull/691.