### PR TITLE
build(deps): drop pyyaml dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 dependencies = [
     "platformdirs",
-    "pyyaml",
     "pywin32; sys_platform == 'win32'",
     "jinja2>=3.1.5",
     "overrides>=7.7.0",


### PR DESCRIPTION
We don't actually use it for anything, and since we're prepping for a major release we might as well drop it.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
