### PR TITLE
ci: update labels for cross-team standardisation

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -2,10 +2,10 @@ settings:
   components:
     - Craft CLI
   labels:
-    - Bug
-    - Enhancement
-    - Spike
-    - Epic
+    - "Type: Bug"
+    - "Type: Enhancement"
+    - "Type: Spike"
+    - "Type: Research"
   # Adds a comment with the JIRA ID
   add_gh_comment: true
   # Reflect changes on JIRA
@@ -19,7 +19,7 @@ settings:
     opened: Untriaged
     closed: done
   label_mapping:
-    Enhancement: Story
-    Bug: Bug
-    Spike: Spike
-    Epic: Epic
+    "Type: Enhancement": Story
+    "Type: Bug": Bug
+    "Type: Spike": Spike
+    "Type: Research": Epic


### PR DESCRIPTION
This updates the label mappings for Jira Sync to work with the current terraform-provided labels.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

