### PR TITLE
fix(printer): stop the printer on destruct

### DIFF
--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import threading
 import time
+import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -228,6 +229,7 @@ class Printer:
             self.spinner.start()
             if _supports_ansi_escape_sequences() and _stream_is_terminal(sys.stderr):
                 print(ANSI_HIDE_CURSOR, end="", file=sys.stderr, flush=True)
+        weakref.finalize(self, self.stop)
 
     def set_terminal_prefix(self, prefix: str) -> None:
         """Set the string to be prepended to every message shown to the terminal."""

--- a/examples.py
+++ b/examples.py
@@ -521,6 +521,10 @@ def example_31():
     time.sleep(6)
     raise CraftError("Error 1\nError 2")
 
+def example_32():
+    emit.progress("Look ma, no cursor!")
+    raise BaseException()
+
 
 # -- end of test cases
 


### PR DESCRIPTION
This stops the printer when garbage collecting it, even if it hasn't been manually stopped. This stops the printer before exiting the process no matter what.

Fixes #334 

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
