### PR TITLE
feat: prepend newlines to details if necessary

### DIFF
--- a/craft_cli/messages.py
+++ b/craft_cli/messages.py
@@ -758,7 +758,8 @@ class Emitter:
 
         # detailed information and/or original exception
         if error.details:
-            text = f"Detailed information: {error.details}"
+            details = _format_details(error.details)
+            text = f"Detailed information: {details}"
             details_stream = None if self._mode == EmitterMode.QUIET else sys.stderr
             self._printer.show(
                 details_stream, text, use_timestamp=use_timestamp, end_line=True
@@ -875,3 +876,10 @@ class Emitter:
 # module-level instantiated Emitter; this is the instance all code shall use and Emitter
 # shall not be instantiated again for the process' run
 emit = Emitter()
+
+
+def _format_details(details: str) -> str:
+    """Prepend a newline to multi-line details, if necessary."""
+    if "\n" in details:
+        return details if details.startswith("\n") else f"\n{details}"
+    return details

--- a/examples.py
+++ b/examples.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import NoReturn
 
+import craft_cli
 from craft_cli import CraftError, EmitterMode, emit
 
 USAGE = """
@@ -547,6 +548,26 @@ def example_32() -> NoReturn:
     """Showcase the cursor being restored even after an uncaught exception."""
     emit.progress("Look ma, no cursor!")
     raise BaseException  # noqa: TRY002
+
+
+def example_33() -> None:
+    """Showcase error reporting."""
+    error = craft_cli.CraftError(
+        message="Something unexpected happened.",
+        details="These are error details.",
+        logpath_report=False,
+    )
+    emit.error(error)
+
+
+def example_34() -> None:
+    """Showcase error reporting (details with multiple lines)."""
+    error = craft_cli.CraftError(
+        message="Something unexpected happened.",
+        details="These are error details.\n- A new line\n- Another line",
+        logpath_report=False,
+    )
+    emit.error(error)
 
 
 # -- end of test cases

--- a/tests/unit/test_messages_emitter.py
+++ b/tests/unit/test_messages_emitter.py
@@ -1007,6 +1007,36 @@ def test_reporterror_detailed_info_final_user_modes(mode, get_initiated_emitter)
     ]
 
 
+@pytest.mark.parametrize("mode", [EmitterMode.BRIEF, EmitterMode.VERBOSE])
+@pytest.mark.parametrize(
+    "details",
+    [
+        pytest.param("Line 1\nLine 2\nLine 3", id="no initial newline"),
+        pytest.param("\nLine 1\nLine 2\nLine 3", id="initial newline"),
+    ],
+)
+def test_reporterror_detailed_info_final_user_modes_newlines(
+    mode, get_initiated_emitter, details
+):
+    """Report an error having long detailed information, in final user modes."""
+    emitter = get_initiated_emitter(mode)
+    error = CraftError("test message", details=details)
+    emitter.error(error)
+
+    full_log_message = f"Full execution log: {repr(emitter._log_filepath)}"
+    assert emitter.printer_calls == [
+        call().show(sys.stderr, "test message", use_timestamp=False, end_line=True),
+        call().show(
+            sys.stderr,
+            "Detailed information: \nLine 1\nLine 2\nLine 3",
+            use_timestamp=False,
+            end_line=True,
+        ),
+        call().show(sys.stderr, full_log_message, use_timestamp=False, end_line=True),
+        call().stop(),
+    ]
+
+
 @pytest.mark.parametrize("mode", [EmitterMode.DEBUG, EmitterMode.TRACE])
 def test_reporterror_detailed_info_developer_modes(mode, get_initiated_emitter):
     """Report an error having detailed information, in developer intended modes."""


### PR DESCRIPTION
This makes an error's details a bit easier to visually identify, in the case of long multi-lined details.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
