### PR TITLE
ci: use hosted runners for QA

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -14,3 +14,8 @@ jobs:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "macos-latest"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.13"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-python-versions: '["3.10", "3.12"]'


### PR DESCRIPTION
We don't need to use self-hosted runners for QA here. This also ensures that we test on a non-x86 architecture.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
