### PR TITLE
feat(dispatcher): add a warning for the default command

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -240,7 +240,8 @@ class Dispatcher:
     :param summary: the summary of the application (for help texts)
     :param extra_global_args: other automatic global arguments than the ones
         provided automatically
-    :param default_command: the command to run if none was specified in the command line
+    :param default_command: The command to run if none was specified in the command line.
+        This parameter will be removed in a future release of craft-cli (#361).
     :param docs_base_url: The base address of the documentation, for help messages.
     """
 
@@ -254,6 +255,7 @@ class Dispatcher:
         default_command: type[BaseCommand] | None = None,
         docs_base_url: str | None = None,
     ) -> None:
+        self._app_name = appname
         self._default_command = default_command
         self._docs_base_url = docs_base_url
         self._help_builder = HelpBuilder(
@@ -525,7 +527,11 @@ class Dispatcher:
             if self._default_command is None:
                 help_text = self._get_general_help(detailed=False)
                 raise ArgumentParsingError(help_text)
-            emit.trace(f"Using default command: {self._default_command.name!r}")
+            emit.progress(
+                f"Using {self._app_name} without a command will be removed in a future release. "
+                f"Use '{self._app_name} {self._default_command.name}' instead.",
+                permanent=True,
+            )
             # validated by BaseCommand
             assert self._default_command.name is not None  # noqa: S101 (use of assert)
             filtered_sysargs.insert(0, self._default_command.name)

--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -528,7 +528,7 @@ class Dispatcher:
                 help_text = self._get_general_help(detailed=False)
                 raise ArgumentParsingError(help_text)
             emit.progress(
-                f"Using {self._app_name} without a command will be removed in a future release. "
+                f"Running {self._app_name} without a command will not be possible in future releases."
                 f"Use '{self._app_name} {self._default_command.name}' instead.",
                 permanent=True,
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,16 @@
 :tocdepth: 2
 
-***************
 Changelog
-***************
+=========
 
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
+
+3.1.0 (2025-MMM-DD)
+-------------------
+
+- Add a deprecation notice when the dispatcher's default command is used.
+  Support for default commands will be removed in a future release.
 
 3.0.0 (2025-Mar-27)
 -------------------

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -114,7 +114,7 @@ def test_dispatcher_command_default_simple():
     assert dispatcher._command_class is cmd2
     assert dispatcher._command_args == []
     mock_progress.assert_any_call(
-        "Using appname without a command will be removed in a future release. "
+        "Running appname without a command will not be possible in future releases."
         "Use 'appname somecommand2' instead.",
         permanent=True,
     )

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -109,11 +109,15 @@ def test_dispatcher_command_default_simple():
     groups = [CommandGroup("title", [cmd1, cmd2])]
     dispatcher = Dispatcher("appname", groups, default_command=cmd2)
 
-    with patch.object(emit, "trace") as mock_trace:
+    with patch.object(emit, "progress") as mock_progress:
         dispatcher.pre_parse_args([])
     assert dispatcher._command_class is cmd2
     assert dispatcher._command_args == []
-    mock_trace.assert_any_call("Using default command: 'somecommand2'")
+    mock_progress.assert_any_call(
+        "Using appname without a command will be removed in a future release. "
+        "Use 'appname somecommand2' instead.",
+        permanent=True,
+    )
 
 
 def test_dispatcher_command_default_with_options():


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Emits a warning when the default command is used. 

Snapcraft is the only *craft app affected by this.

Creates #361
Unblocks https://github.com/canonical/snapcraft/issues/5525
(SNAPCRAFT-1149)