### PR TITLE
ci: install python3-venv in release workflow (#414)

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -14,7 +14,9 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Install uv
-        run: sudo snap install --classic astral-uv
+        run: |
+          sudo snap install --classic astral-uv
+          sudo apt-get install --yes python3-venv
       - name: Checkout
         uses: actions/checkout@v4
       - name: Fetch tag annotations


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

If python3-venv isn't installed, setuptools will fail.

From https://github.com/canonical/starbase/pull/414