### PR TITLE
fix: correct typo in default command warning

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -528,7 +528,7 @@ class Dispatcher:
                 help_text = self._get_general_help(detailed=False)
                 raise ArgumentParsingError(help_text)
             emit.progress(
-                f"Running {self._app_name} without a command will not be possible in future releases."
+                f"Running {self._app_name} without a command will not be possible in future releases. "
                 f"Use '{self._app_name} {self._default_command.name}' instead.",
                 permanent=True,
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ included in each version.
 
 Bug fixes:
 
-- Corrects a typo in the deprecation notice for using the default command.
+- Correct a typo in the deprecation notice for using the default command.
 
 .. _release-3.1.0:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+.. _release-3.1.1:
+
+3.1.1 (2025-MMM-DD)
+-------------------
+
+Bug fixes:
+
+- Corrects a typo in the deprecation notice for using the default command.
+
 .. _release-3.1.0:
 
 3.1.0 (2025-Jul-17)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ included in each version.
 
 .. _release-3.1.1:
 
-3.1.1 (2025-MMM-DD)
+3.1.1 (2025-Jul-18)
 -------------------
 
 Bug fixes:

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -114,7 +114,7 @@ def test_dispatcher_command_default_simple():
     assert dispatcher._command_class is cmd2
     assert dispatcher._command_args == []
     mock_progress.assert_any_call(
-        "Running appname without a command will not be possible in future releases."
+        "Running appname without a command will not be possible in future releases. "
         "Use 'appname somecommand2' instead.",
         permanent=True,
     )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

I didn't notice the missing space, because I was testing in a narrow terminal.