### PR TITLE
fix: cleanup errors when stopping printer in tests

### DIFF
--- a/craft_cli/printer.py
+++ b/craft_cli/printer.py
@@ -494,11 +494,15 @@ class Printer:
         - add a new line to the screen (if needed)
         - close the log file
         """
+        if self.stopped:
+            # Safe no-op
+            return
         if not TESTMODE:
-            self.spinner.stop()
+            if self.spinner.is_alive():
+                self.spinner.stop()
             if _supports_ansi_escape_sequences() and _stream_is_terminal(sys.stderr):
                 print(ANSI_SHOW_CURSOR, end="", file=sys.stderr, flush=True)
-        if self.unfinished_stream is not None:
+        if self.unfinished_stream is not None and not self.unfinished_stream.closed:
             # With unfinished_stream set, the prv_msg object is valid.
             if self.prv_msg is not None and self.prv_msg.ephemeral:
                 # If the last printed message is of 'ephemeral' type, the stop

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+.. _release-3.1.2:
+
+3.1.2 (2025-Jul-22)
+-------------------
+
+Bug fixes:
+
+- Fixed the many spurious errors when stopping the printer during tests.
+
 .. _release-3.1.1:
 
 3.1.1 (2025-Jul-18)

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -1543,8 +1543,7 @@ def test_testmode_multiple_stop(log_filepath, monkeypatch):
     printer.stop()
 
 
-@pytest.mark.parametrize("bla", [1, 2, 3])
-def test_unfinished_stream_closed(log_filepath, mocker, bla):
+def test_unfinished_stream_closed(log_filepath, mocker):
     """Test stopping the Printer with an unfinished message on a stream that's closed."""
 
     # The issue only happened when the stream is connected to a terminal


### PR DESCRIPTION
The errors happened because we now unconditionally stop() the Printer at process exit, but the stop() method was not conscious enough of the state of the things it was trying to stop - unfinished streams that might already be closed, spinner threads that were never started, etc.

Fixes #356 and #341

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
