### PR TITLE
fix: filter other commands by name instead of type

### DIFF
--- a/craft_cli/helptexts.py
+++ b/craft_cli/helptexts.py
@@ -475,7 +475,7 @@ class HelpBuilder:
         else:
             raise RuntimeError("Internal inconsistency in commands groups")
         other_command_names = [
-            c.name for c in command_group.commands if not isinstance(command, c)
+            c.name for c in command_group.commands if c.name != command.name
         ]
 
         if output_format == OutputFormat.markdown:

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -25,7 +25,8 @@ def create_command(
     hidden: bool = False,
     overview: str = "",
     class_name: str = "MyCommand",
-) -> type["BaseCommand"]:
+    base_class: type[BaseCommand] = BaseCommand,
+) -> type[BaseCommand]:
     """Helper to create commands."""
     attribs = {
         "name": name,
@@ -36,4 +37,4 @@ def create_command(
         "needs_config": False,
         "run": lambda parsed_args: None,
     }
-    return type(class_name, (BaseCommand,), attribs)
+    return type(class_name, (base_class,), attribs)

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -443,8 +443,11 @@ def test_command_help_text_no_parameters(docs_url, output_format):
         Multiline!
     """
     )
-    cmd1 = create_command("somecommand", "Command one line help.", overview=overview)
     cmd2 = create_command("other-cmd-2", "Some help.")
+    # Inherit from cmd2 to check that superclasses are treated as different commands.
+    cmd1 = create_command(
+        "somecommand", "Command one line help.", overview=overview, base_class=cmd2
+    )
     cmd3 = create_command("other-cmd-3", "Some help.")
     cmd4 = create_command("other-cmd-4", "Some help.")
     command_groups = [


### PR DESCRIPTION
Previously, a command like craft_appplication.command.TestCommand, which inherits from PackCommand, would omit the parent command in the "see also" section.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?