### PR TITLE
chore: clean up an unused field from the completion script

### DIFF
--- a/craft_cli/completion/bash_completion.sh.j2
+++ b/craft_cli/completion/bash_completion.sh.j2
@@ -63,7 +63,7 @@ _complete_{{ shell_cmd }}(){
     {% endfor %}
   esac
 
-  COMPREPLY=($(compgen -W "${all_cmds[*]} ${global_args[*]}" -- "$cur"))
+  COMPREPLY=($(compgen -W "${all_cmds[*]}" -- "$cur"))
 }
 
 complete -F _complete_{{ shell_cmd }} {{ shell_cmd }}

--- a/craft_cli/completion/completion.py
+++ b/craft_cli/completion/completion.py
@@ -250,7 +250,6 @@ def complete(shell_cmd: str, get_app_info: Callable[[], DispatcherAndConfig]) ->
     return template.render(
         shell_cmd=shell_cmd,
         commands=command_map,
-        global_args=dispatcher.global_arguments,
         global_opts=global_opts,
     )
 

--- a/tests/integration/test_completion/expected_script.sh
+++ b/tests/integration/test_completion/expected_script.sh
@@ -77,7 +77,7 @@ _complete_testcraft(){
       ;;
   esac
 
-  COMPREPLY=($(compgen -W "${all_cmds[*]} ${global_args[*]}" -- "$cur"))
+  COMPREPLY=($(compgen -W "${all_cmds[*]}" -- "$cur"))
 }
 
 complete -F _complete_testcraft testcraft


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

The result of a lint workflow on one of our PR's ([here](https://github.com/canonical/craft-cli/actions/runs/16973778349/job/48117243596?pr=372#step:6:22)) revealed that one of the fields on the completion script wasn't actually being used or filled in as anything.