### PR TITLE
chore: prepare for Python 3.14

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,6 +16,6 @@ jobs:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "macos-latest"]'
-      fast-test-python-versions: '["3.10", "3.12", "3.13"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.13", "3.14", "3.14+freethreaded"]'
       slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
-      slow-test-python-versions: '["3.10", "3.12"]'
+      slow-test-python-versions: '["3.10", "3.12", "3.14", "3.14+freethreaded"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "platformdirs",
     "pywin32; sys_platform == 'win32'",
     "jinja2>=3.1.5",
-    "overrides>=7.7.0",
     "typing-extensions",
 ]
 classifiers = [
@@ -19,8 +18,8 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -60,7 +60,7 @@ def test_logging_in_multiprocess(tmp_path):
 
     emitter_logged = strip_timestamps(emitter_log.read_text())
 
-    if sys.platform == "linux":
+    if sys.platform == "linux" and sys.version_info < (3, 14):
         # Expect two messages from the parent process, then two from the child process,
         # then a final one from the parent again.
         expected_text = dedent(

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -29,7 +29,7 @@ from craft_cli.completion.completion import (
     Option,
     get_set_flags,
 )
-from overrides import override
+from typing_extensions import override
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,6 @@ name = "craft-cli"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
-    { name = "overrides" },
     { name = "platformdirs" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
@@ -405,7 +404,6 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.5" },
-    { name = "overrides", specifier = ">=7.7.0" },
     { name = "platformdirs" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
@@ -503,7 +501,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -967,15 +965,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
-name = "overrides"
-version = "7.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This makes the needed changes for Python 3.14:

1. Removes the incompatible overrides module (uses typing instead)
2. Adds both Python 3.14 and the freethreaded build to CI

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
