### PR TITLE
fix: don't recommend hidden commands

### DIFF
--- a/craft_cli/helptexts.py
+++ b/craft_cli/helptexts.py
@@ -475,7 +475,9 @@ class HelpBuilder:
         else:
             raise RuntimeError("Internal inconsistency in commands groups")
         other_command_names = [
-            c.name for c in command_group.commands if not isinstance(command, c)
+            other_command.name
+            for other_command in command_group.commands
+            if not isinstance(command, other_command) and not other_command.hidden
         ]
 
         if output_format == OutputFormat.markdown:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+.. _release-3.4.1:
+
+3.4.1 (2026-06-17)
+------------------
+
+Bug fixes:
+
+- Command help no longer shows hidden commands in the "See also" section.
+
 .. _release-3.4.0:
 
 3.4.0 (2026-04-08)

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -688,6 +688,99 @@ def test_command_help_text_with_parameters_with_no_help(docs_url, output_format)
 
 
 @pytest.mark.parametrize("output_format", list(OutputFormat))
+def test_command_help_text_see_also(docs_url, output_format):
+    """Only show non-hidden commands from the same group."""
+    overview = textwrap.dedent(
+        """
+        Quite some long text.
+
+        Multiline!
+    """
+    )
+    cmd1 = create_command("somecommand", "Command one line help.", overview=overview)
+    cmd2 = create_command("valid-cmd-2", "Some help.")
+    cmd3 = create_command("deprecated-cmd-3", "Some help.", hidden=True)
+    cmd4 = create_command("valid-cmd-4", "Some help.")
+    cmd5 = create_command("valid-cmd-5", "Some help.")
+    cmd6 = create_command("deprecated-cmd-6", "Some help.", hidden=True)
+    command_groups = [
+        # cmd1 is filtered because it's the active command
+        # cmd3 is filtered because it's hidden
+        CommandGroup("group1", [cmd1, cmd2, cmd3, cmd4]),
+        # cmd5 and cmd6 are filtered because they're in a different group
+        CommandGroup("group2", [cmd5, cmd6]),
+    ]
+
+    options = [
+        ("-h, --help", "Show this help message and exit."),
+        ("-q, --quiet", "Only show warnings and errors, not progress."),
+        ("--name", "The name of the charm."),
+        ("--revision", "The revision to release (defaults to latest)."),
+    ]
+
+    help_builder = HelpBuilder("testapp", "general summary", command_groups, docs_url)
+    text = help_builder.get_command_help(cmd1(None), options, output_format)
+
+    expected_plain = textwrap.dedent(
+        """\
+        Usage:
+            testapp somecommand [options]
+
+        Summary:
+            Quite some long text.
+
+            Multiline!
+
+        Options:
+             -h, --help:  Show this help message and exit.
+            -q, --quiet:  Only show warnings and errors, not progress.
+                 --name:  The name of the charm.
+             --revision:  The revision to release (defaults to latest).
+
+        See also:
+            valid-cmd-2
+            valid-cmd-4
+
+        For a summary of all commands, run 'testapp help --all'.
+    """
+    )
+    if docs_url:
+        expected_plain += (
+            "For more information, check out: "
+            "www.craft-app.com/docs/3.14159/reference/commands/somecommand\n"
+        )
+    expected_markdown = textwrap.dedent(
+        """\
+        ## Usage:
+        ```text
+        testapp somecommand [options]
+        ```
+
+        ## Summary:
+
+        Quite some long text.
+
+        Multiline!
+
+        ## Options:
+        | | |
+        |-|-|
+        | `-h, --help` | Show this help message and exit. |
+        | `-q, --quiet` | Only show warnings and errors, not progress. |
+        | `--name` | The name of the charm. |
+        | `--revision` | The revision to release (defaults to latest). |
+
+        ## See also:
+        - `valid-cmd-2`
+        - `valid-cmd-4`
+    """
+    )
+    assert text == (
+        expected_plain if output_format == OutputFormat.plain else expected_markdown
+    )
+
+
+@pytest.mark.parametrize("output_format", list(OutputFormat))
 def test_command_help_text_complex_overview(docs_url, output_format):
     """The overviews are processed in different ways."""
     overview = textwrap.dedent(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Fixes a bug where hidden commands were shown in the 'See also' section of a command's help text.


Fixes https://github.com/canonical/craft-cli/issues/449
(CRAFT-5213)