### PR TITLE
docs: declare slug in config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,9 @@ html_context = {
     "github_url": "https://github.com/canonical/craft-cli",
 }
 
+# The project slug passed to the sphinx-notfound-page extension
+slug = "craft-cli"
+
 # Add extensions
 extensions = [
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
Canonical Sphinx uses this to configure the sphinx-notfound-page extension.

Live 404 page: https://documentation.ubuntu.com/craft-cli/oops

PR build 404 page: https://canonical-ubuntu-documentation-library--470.com.readthedocs.build/craft-cli/470/oops