### PR TITLE
ci: add actions: read permission to policy job

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -11,6 +11,7 @@ jobs:
   policy:
     permissions:
       contents: read
+      actions: read
       security-events: write
     uses: canonical/starflow/.github/workflows/policy.yaml@main
   python-scans:


### PR DESCRIPTION
## Description

Adds `actions: read` to the `policy` job's permissions in `.github/workflows/policy.yaml`, matching [Snapcraft's policy workflow](https://github.com/canonical/snapcraft/blob/main/.github/workflows/policy.yaml).

The policy workflow (via starflow) requires read access to actions; without this permission the job can fail.