### PR TITLE
feat: error early when help message is missing

### DIFF
--- a/craft_cli/dispatcher.py
+++ b/craft_cli/dispatcher.py
@@ -393,18 +393,23 @@ class Dispatcher:
         # produce the complete help message for the command
         command_options = self._get_global_options()
         for action in parser._actions:  # noqa: SLF001
-            # store the different options if present, otherwise it's just the dest
-            help_text = "" if action.help is None else action.help
             if action.option_strings:
-                command_options.append((", ".join(action.option_strings), help_text))
+                indicator = ", ".join(action.option_strings)
+            elif action.metavar is None:
+                indicator = action.dest
             else:
-                if action.metavar is None:
-                    dest = action.dest
-                else:
-                    # may be a tuple, but only for options
-                    assert isinstance(action.metavar, str)  # noqa: S101 (use of assert)
-                    dest = action.metavar
-                command_options.append((dest, help_text))
+                # may be a tuple, but only for options
+                assert isinstance(action.metavar, str)  # noqa: S101 (use of assert)
+                indicator = action.metavar
+
+            if action.help is None:
+                raise ValueError(
+                    f"Bad command configuration: argument {indicator!r} in command "
+                    f"{command.name!r} is missing help text. Add a 'help' argument "
+                    "to add_argument() or set help=argparse.SUPPRESS."
+                )
+
+            command_options.append((indicator, action.help))
 
         return self._help_builder.get_command_help(
             command, command_options, output_format

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -1344,7 +1344,7 @@ def test_tool_exec_command_dash_help_reverse(help_option):
 
 @pytest.mark.parametrize("help_option", ["-h", "--help"])
 def test_tool_exec_command_dash_help_missing_params(help_option):
-    """Execute a command (which needs params) asking for help."""
+    """Missing positional help raises a clear configuration error for dash-help too."""
 
     def fill_parser(self, parser):
         parser.add_argument("mandatory")
@@ -1354,24 +1354,14 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
     command_groups = [CommandGroup("group", [cmd])]
     dispatcher = Dispatcher("testapp", command_groups)
 
-    with patch("craft_cli.helptexts.HelpBuilder.get_command_help") as mock:
-        mock.return_value = "test help"
-        with pytest.raises(ProvideHelpException) as exc_cm:
-            dispatcher.pre_parse_args(["somecommand", help_option])
-
-    # check the result of the full help builder is what is transmitted
-    assert str(exc_cm.value) == "test help"
-
-    # check the given information to the help text builder
-    args = mock.call_args[0]
-    assert args[0].__class__ == cmd
-    assert sorted(x[0] for x in args[1]) == [
-        "--verbosity",
-        "-h, --help",
-        "-q, --quiet",
-        "-v, --verbose",
-        "mandatory",
-    ]
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Bad command configuration: argument 'mandatory' in command "
+            r"'somecommand' is missing help text\."
+        ),
+    ):
+        dispatcher.pre_parse_args(["somecommand", help_option])
 
 
 def test_tool_exec_command_wrong_option():
@@ -1526,7 +1516,7 @@ def test_tool_exec_help_command_on_command_complex():
 
 
 def test_tool_exec_help_command_on_command_no_help():
-    """Execute the app asking for help on a command with an options and params without help."""
+    """Missing positional help raises a clear configuration error."""
 
     def fill_parser(self, parser):
         parser.add_argument("param")
@@ -1537,29 +1527,36 @@ def test_tool_exec_help_command_on_command_no_help():
     command_groups = [CommandGroup("group", [cmd])]
     dispatcher = Dispatcher("testapp", command_groups)
 
-    with patch("craft_cli.helptexts.HelpBuilder.get_command_help") as mock:
-        mock.return_value = "test help"
-        with pytest.raises(ProvideHelpException) as exc_cm:
-            dispatcher.pre_parse_args(["help", "somecommand"])
-
-    # check the result of the help builder is what is transmitted
-    assert str(exc_cm.value) == "test help"
-
-    # check the given information to the help text builder
-    args = mock.call_args[0]
-    assert args[0].__class__ == cmd
-    expected_options = [
-        ("--option", ""),
-        (
-            "--verbosity",
-            "Set the verbosity level to 'quiet', 'brief', 'verbose', 'debug' or 'trace'",
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Bad command configuration: argument 'param' in command "
+            r"'somecommand' is missing help text\."
         ),
-        ("-h, --help", "Show this help message and exit"),
-        ("-q, --quiet", "Only show warnings and errors, not progress"),
-        ("-v, --verbose", "Show debug information and be more verbose"),
-        ("param", ""),
-    ]
-    assert sorted(args[1]) == expected_options
+    ):
+        dispatcher.pre_parse_args(["help", "somecommand"])
+
+
+def test_tool_exec_help_command_on_command_option_no_help():
+    """Missing option help raises a clear configuration error."""
+
+    def fill_parser(self, parser):
+        parser.add_argument("param", help="A parameter.")
+        parser.add_argument("--option")
+
+    cmd = create_command("somecommand", "This command does that.")
+    cmd.fill_parser = fill_parser  # ty: ignore[invalid-assignment]
+    command_groups = [CommandGroup("group", [cmd])]
+    dispatcher = Dispatcher("testapp", command_groups)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Bad command configuration: argument '--option' in command "
+            r"'somecommand' is missing help text\."
+        ),
+    ):
+        dispatcher.pre_parse_args(["help", "somecommand"])
 
 
 def test_tool_exec_help_command_on_command_wrong():


### PR DESCRIPTION
Raise a command configuration error on help generation instead of
allowing the help flow to fail later.

Fixes #242

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
